### PR TITLE
Harden packaged desktop runtime mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ versioning; dates are ISO. Version is sourced from `package.json` and surfaced b
   polling-first negotiation without startup console warnings.
 - Packaged Desktop ignores arbitrary launch-directory `.env` files and accepts
   configuration only from deliberately shipped package resources.
+- Packaged Desktop cannot inherit Vite, DevTools, or other development behavior
+  from a launcher that sets `NODE_ENV=development`.
 - Outreach initiation now prepares idempotent lawyer drafts in the same action,
   while approval and irreversible provider delivery remain separate controls.
 - Lawyer replies can be recorded through an owner-scoped workflow action and

--- a/docs/FINAL_VERIFICATION_REPORT.md
+++ b/docs/FINAL_VERIFICATION_REPORT.md
@@ -1,8 +1,8 @@
 # Final Verification Report
 
-Date: 2026-07-15
+Date: 2026-07-16
 Branch: `main`
-Commit: `677a46a62577792c4acf2811b475ca2f1bf4d040`
+Commit: `39cea391a88f9733f141e69328e9679cae2aab4a`
 
 This report separates reproducible repository evidence from target-environment
 acceptance. It supersedes the 2026-07-06 phase snapshot.
@@ -24,9 +24,10 @@ acceptance. It supersedes the 2026-07-06 phase snapshot.
 | Unpacked Windows packaging | Pass with tracked LARO icon |
 | Packaged `/api/health` | `healthy`, database ready, version 1.3.0, production |
 | Desktop scanner contract | Scoped 15-minute token; real bytes/hash; owner/MIME enforcement |
-| Protected-main CI | Actions run `29455232706`; Node and Python jobs passed |
-| Windows package workflow | Actions run `29455232654`; gate, build, ABI check, package, checksum, and artifact upload passed |
+| Protected-main CI | Actions run `29457000334`; Node and Python jobs passed |
+| Windows package workflow | Actions run `29457000381`; gate, build, ABI check, package, checksum, and artifact upload passed |
 | Packaged matching assets | Seven aligned legal categories; invalid legacy dataset absent |
+| Dependency graph | One canonical Node workspace; 0 open Dependabot alerts |
 
 `npm run readiness:production` also passed with strong target-like secrets. The
 readiness command now restores the Node SQLite ABI itself after Electron
@@ -58,8 +59,8 @@ A second packaged-window run exercised the rebuilt scanner surface:
 - Settings opened and returned to evidence collection; the viewport had no
   horizontal overflow or overlapping controls.
 
-The CI portable artifact is 104,514,968 bytes with SHA-256
-`c6cf367f112b4dc4fd64d749666f00ae169a175a4f2a168aaf1159a06dc3cb38`.
+The CI portable artifact is 104,512,348 bytes with SHA-256
+`af901f1624b0f394c624b297492d2f7622f942ec8d6c3ca850bceee6476bbdfa`.
 The downloaded executable matched its published checksum, launched the real
 dashboard window with an active renderer, and did not reproduce the obsolete
 `dist/main/index.js` startup error. Its packaged resources contain the current
@@ -87,6 +88,8 @@ reports `NotSigned`, matching the external signing gate below.
 - Lawyer matching loads a valid curated terminology dataset whose seven category
   keys are checked against the specialization taxonomy. It no longer silently
   falls back around the truncated asset or claims unsupported 877k-case scoring.
+- The obsolete nested `assets` npm/Electron workspace was removed. It was not a
+  runnable product surface and was the sole source of 72 stale dependency alerts.
 - `main` requires pull requests, strict Node/Python status checks, stale-review
   dismissal, resolved review conversations, and disallows force pushes/deletion.
 

--- a/src-main/desktopPort.ts
+++ b/src-main/desktopPort.ts
@@ -14,3 +14,15 @@ export function resolveDesktopServerPort(redirectBase: string | undefined): numb
     return 0;
   }
 }
+
+/**
+ * A packaged executable must never inherit development-only renderer behavior
+ * from the launching shell. In particular, NODE_ENV=development must not make
+ * a release build try to load the Vite server or expose development menus.
+ */
+export function isDesktopDevelopmentMode(
+  isPackaged: boolean,
+  nodeEnv: string | undefined
+): boolean {
+  return !isPackaged && nodeEnv === 'development';
+}

--- a/src-main/index.ts
+++ b/src-main/index.ts
@@ -13,7 +13,7 @@ import {
 } from './database';
 import { FileScanner } from './scanner';
 import { FileUploader } from './uploader';
-import { resolveDesktopServerPort } from './desktopPort';
+import { isDesktopDevelopmentMode, resolveDesktopServerPort } from './desktopPort';
 // NOTE: server/index.ts reads `.env` (dotenv) at import time, so it is imported
 // lazily in startApp() AFTER we pin NODE_ENV from app.isPackaged. This guarantees
 // a packaged build runs the server in production mode even if the bundled .env
@@ -21,7 +21,7 @@ import { resolveDesktopServerPort } from './desktopPort';
 
 const DEFAULT_PORT = 3000;
 let laroUrl = `http://127.0.0.1:${DEFAULT_PORT}`;
-const isDev = process.env.NODE_ENV === 'development';
+const isDev = isDesktopDevelopmentMode(app.isPackaged, process.env.NODE_ENV);
 
 /**
  * Phase 006/007 — per-install secret bootstrap.

--- a/tests/backend/listen.test.ts
+++ b/tests/backend/listen.test.ts
@@ -1,7 +1,10 @@
 import { createServer, type Server } from 'http';
 import { afterEach, describe, expect, it } from 'vitest';
 import { listenHttpServer } from '../../server/listen';
-import { resolveDesktopServerPort } from '../../src-main/desktopPort';
+import {
+  isDesktopDevelopmentMode,
+  resolveDesktopServerPort,
+} from '../../src-main/desktopPort';
 
 const servers: Server[] = [];
 
@@ -44,5 +47,18 @@ describe('packaged desktop port selection', () => {
   it('preserves the port registered for a loopback OAuth callback', () => {
     expect(resolveDesktopServerPort('http://localhost:3000')).toBe(3000);
     expect(resolveDesktopServerPort('http://127.0.0.1:8768/api/oauth/callback')).toBe(8768);
+  });
+});
+
+describe('desktop runtime mode', () => {
+  it('honors development mode only for an unpackaged Electron process', () => {
+    expect(isDesktopDevelopmentMode(false, 'development')).toBe(true);
+    expect(isDesktopDevelopmentMode(false, 'production')).toBe(false);
+  });
+
+  it('never enables development behavior in a packaged executable', () => {
+    expect(isDesktopDevelopmentMode(true, 'development')).toBe(false);
+    expect(isDesktopDevelopmentMode(true, 'production')).toBe(false);
+    expect(isDesktopDevelopmentMode(true, undefined)).toBe(false);
   });
 });

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -158,6 +158,14 @@ describe('production readiness regressions', () => {
     expect(main).not.toContain('await startServer(PORT)');
   });
 
+  it('does not inherit development-only behavior in a packaged executable', () => {
+    const main = readFileSync(join(ROOT, 'src-main/index.ts'), 'utf8');
+    const desktopRuntime = readFileSync(join(ROOT, 'src-main/desktopPort.ts'), 'utf8');
+    expect(main).toContain('isDesktopDevelopmentMode(app.isPackaged, process.env.NODE_ENV)');
+    expect(main).not.toContain("const isDev = process.env.NODE_ENV === 'development'");
+    expect(desktopRuntime).toContain("return !isPackaged && nodeEnv === 'development'");
+  });
+
   it('reports the package version consistently across operational endpoints', () => {
     const health = readFileSync(join(ROOT, 'server/index.ts'), 'utf8');
     const system = readFileSync(join(ROOT, 'server/_core/systemRouter.ts'), 'utf8');


### PR DESCRIPTION
## Summary
- prevent packaged Electron builds from inheriting Vite/DevTools behavior when the launching environment sets `NODE_ENV=development`
- add direct unit and production-readiness regression coverage
- refresh the final verification report to the current protected-main artifact and dependency state

## Verification
- targeted Vitest: 27 passed
- `npm run gate`: 32 files, 220 tests passed; all blocking gates passed
- `npm run dist:win`: passed
- hostile packaged launch with `NODE_ENV=development`: `/api/health` reported `healthy`, `production`, version `1.3.0`; no DevTools or startup-error window