### PR TITLE
Support Azure Artifact Signing releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build-windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -24,18 +27,44 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         shell: pwsh
         env:
+          WINDOWS_SIGNING_PROVIDER: ${{ vars.WINDOWS_SIGNING_PROVIDER }}
           WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
           WINDOWS_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_ARTIFACT_SIGNING_ENDPOINT: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          AZURE_ARTIFACT_SIGNING_ACCOUNT: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
+          AZURE_ARTIFACT_SIGNING_PROFILE: ${{ vars.AZURE_ARTIFACT_SIGNING_PROFILE }}
         run: |
           $version = (Get-Content package.json -Raw | ConvertFrom-Json).version
           if ('${{ github.ref_name }}' -ne "v$version") {
             throw "Tag ${{ github.ref_name }} does not match package version v$version"
           }
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CSC_LINK)) {
-            throw 'WINDOWS_CSC_LINK is required for tagged releases'
-          }
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CSC_KEY_PASSWORD)) {
-            throw 'WINDOWS_CSC_KEY_PASSWORD is required for tagged releases'
+          if ($env:WINDOWS_SIGNING_PROVIDER -eq 'pfx') {
+            if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CSC_LINK)) {
+              throw 'WINDOWS_CSC_LINK is required when WINDOWS_SIGNING_PROVIDER=pfx'
+            }
+            if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CSC_KEY_PASSWORD)) {
+              throw 'WINDOWS_CSC_KEY_PASSWORD is required when WINDOWS_SIGNING_PROVIDER=pfx'
+            }
+          } elseif ($env:WINDOWS_SIGNING_PROVIDER -eq 'azure-artifact-signing') {
+            $required = @(
+              'AZURE_CLIENT_ID',
+              'AZURE_TENANT_ID',
+              'AZURE_SUBSCRIPTION_ID',
+              'AZURE_ARTIFACT_SIGNING_ENDPOINT',
+              'AZURE_ARTIFACT_SIGNING_ACCOUNT',
+              'AZURE_ARTIFACT_SIGNING_PROFILE'
+            )
+            $missing = @($required | Where-Object {
+              [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+            })
+            if ($missing.Count -gt 0) {
+              throw "Azure Artifact Signing configuration is incomplete: $($missing -join ', ')"
+            }
+          } else {
+            throw 'WINDOWS_SIGNING_PROVIDER must be pfx or azure-artifact-signing for tagged releases'
           }
       - name: Validate external release acceptance
         if: startsWith(github.ref, 'refs/tags/')
@@ -51,9 +80,10 @@ jobs:
       - name: Package Windows portable application
         run: npx electron-builder --win --publish never
         env:
-          CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
-      - name: Verify and stage release artifact
+          CSC_LINK: ${{ vars.WINDOWS_SIGNING_PROVIDER == 'pfx' && secrets.WINDOWS_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ vars.WINDOWS_SIGNING_PROVIDER == 'pfx' && secrets.WINDOWS_CSC_KEY_PASSWORD || '' }}
+      - name: Resolve portable artifact
+        id: portable
         shell: pwsh
         run: |
           $version = (Get-Content package.json -Raw | ConvertFrom-Json).version
@@ -61,7 +91,30 @@ jobs:
           if ($matches.Count -ne 1) {
             throw "Expected one portable executable, found $($matches.Count)"
           }
-          $portable = $matches[0]
+          "path=$($matches[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+      - name: Sign in to Azure with GitHub OIDC
+        if: startsWith(github.ref, 'refs/tags/') && vars.WINDOWS_SIGNING_PROVIDER == 'azure-artifact-signing'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign portable application with Azure Artifact Signing
+        if: startsWith(github.ref, 'refs/tags/') && vars.WINDOWS_SIGNING_PROVIDER == 'azure-artifact-signing'
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_PROFILE }}
+          files: ${{ steps.portable.outputs.path }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+      - name: Verify and stage release artifact
+        shell: pwsh
+        run: |
+          $version = (Get-Content package.json -Raw | ConvertFrom-Json).version
+          $portable = Get-Item -LiteralPath '${{ steps.portable.outputs.path }}'
           if ('${{ github.ref_type }}' -eq 'tag') {
             $signature = Get-AuthenticodeSignature $portable.FullName
             if ($signature.Status -ne 'Valid') {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ versioning; dates are ISO. Version is sourced from `package.json` and surfaced b
   and operational endpoints report the package version consistently.
 - Tagged Windows releases now fail closed on tag/version mismatch, missing
   signing credentials, or an invalid signature and publish a SHA-256 checksum.
+- Tagged Windows releases support Microsoft Artifact Signing through GitHub OIDC
+  as the preferred alternative to storing a PFX certificate in GitHub secrets.
 
 ## [1.3.0] — 2026-07-06
 Closing renderer-independent Partials with real code.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -7,14 +7,32 @@ semantic versions from `package.json`, add the matching changelog entry, and tag
 the accepted main commit as `vX.Y.Z`. Tags build and publish the Windows portable
 artifact through `.github/workflows/build.yml`.
 
-Tagged releases fail closed unless the tag exactly matches `package.json`,
-`WINDOWS_CSC_LINK` and `WINDOWS_CSC_KEY_PASSWORD` repository secrets are set,
-`release-acceptance.json` records approved public-brand and live-provider gates,
-and Windows reports the executable's Authenticode signature as `Valid`. Each
-approval must identify its approver, timestamp, evidence references, and, for
-providers, the tested provider scope. The workflow publishes only the versioned
-portable executable and its SHA-256 checksum. Main-branch and manual builds
-remain internal validation artifacts.
+Tagged releases fail closed unless the tag exactly matches `package.json`, a
+supported signing provider is fully configured, `release-acceptance.json`
+records approved public-brand and live-provider gates, and Windows reports the
+executable's Authenticode signature as `Valid`. Each approval must identify its
+approver, timestamp, evidence references, and, for providers, the tested
+provider scope. The workflow publishes only the versioned portable executable
+and its SHA-256 checksum. Main-branch and manual builds remain internal
+validation artifacts.
+
+## Windows Signing
+
+Set the repository variable `WINDOWS_SIGNING_PROVIDER` to one of:
+
+- `azure-artifact-signing` (preferred): uses Microsoft Artifact Signing with
+  GitHub OIDC. Store `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and
+  `AZURE_SUBSCRIPTION_ID` as repository secrets. Store
+  `AZURE_ARTIFACT_SIGNING_ENDPOINT`, `AZURE_ARTIFACT_SIGNING_ACCOUNT`, and
+  `AZURE_ARTIFACT_SIGNING_PROFILE` as repository variables. The Azure identity
+  needs the Artifact Signing Certificate Profile Signer role and a federated
+  credential for the release tag's GitHub OIDC subject.
+- `pfx`: store the base64-encoded certificate in `WINDOWS_CSC_LINK` and its
+  password in `WINDOWS_CSC_KEY_PASSWORD` as repository secrets.
+
+Neither route permits an unsigned tagged release. Azure signing uses Microsoft's
+RFC 3161 timestamp service so the signature remains verifiable after the
+short-lived signing certificate expires.
 
 ## Pre-release Gates
 

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -90,7 +90,13 @@ describe('production readiness regressions', () => {
     const workflow = readFileSync(join(ROOT, '.github/workflows/build.yml'), 'utf8');
     const acceptance = JSON.parse(readFileSync(join(ROOT, 'release-acceptance.json'), 'utf8'));
     const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
-    expect(workflow).toContain('WINDOWS_CSC_LINK is required for tagged releases');
+    expect(workflow).toContain('WINDOWS_SIGNING_PROVIDER must be pfx or azure-artifact-signing');
+    expect(workflow).toContain('WINDOWS_CSC_LINK is required when WINDOWS_SIGNING_PROVIDER=pfx');
+    expect(workflow).toContain('Azure Artifact Signing configuration is incomplete');
+    expect(workflow).toContain('id-token: write');
+    expect(workflow).toContain('uses: azure/login@v3');
+    expect(workflow).toContain('uses: azure/artifact-signing-action@v2');
+    expect(workflow).toContain('timestamp-rfc3161: http://timestamp.acs.microsoft.com');
     expect(workflow).toContain("Tag ${{ github.ref_name }} does not match package version");
     expect(workflow).toContain('release-acceptance.mjs --require-approved --tag');
     expect(workflow).toContain("$signature.Status -ne 'Valid'");


### PR DESCRIPTION
## Summary
- add Microsoft Artifact Signing as the preferred cloud-signing path for tagged Windows releases
- authenticate through GitHub OIDC instead of storing private certificate material
- retain PFX signing as an explicit fallback
- fail closed on incomplete provider configuration and continue requiring Authenticode `Valid`
- document both signing paths and add production-readiness regression coverage

## Verification
- workflow YAML parsed successfully
- targeted production-readiness suite: 21 passed
- `npm run gate`: 32 files, 220 tests passed; all blocking gates passed

No Azure resource or charge is created by this PR.