### PR TITLE
Support SSL.com eSigner releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,10 @@ jobs:
           AZURE_ARTIFACT_SIGNING_ENDPOINT: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
           AZURE_ARTIFACT_SIGNING_ACCOUNT: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
           AZURE_ARTIFACT_SIGNING_PROFILE: ${{ vars.AZURE_ARTIFACT_SIGNING_PROFILE }}
+          SSL_COM_USERNAME: ${{ secrets.SSL_COM_USERNAME }}
+          SSL_COM_PASSWORD: ${{ secrets.SSL_COM_PASSWORD }}
+          SSL_COM_CREDENTIAL_ID: ${{ secrets.SSL_COM_CREDENTIAL_ID }}
+          SSL_COM_TOTP_SECRET: ${{ secrets.SSL_COM_TOTP_SECRET }}
         run: |
           $version = (Get-Content package.json -Raw | ConvertFrom-Json).version
           if ('${{ github.ref_name }}' -ne "v$version") {
@@ -63,8 +67,21 @@ jobs:
             if ($missing.Count -gt 0) {
               throw "Azure Artifact Signing configuration is incomplete: $($missing -join ', ')"
             }
+          } elseif ($env:WINDOWS_SIGNING_PROVIDER -eq 'sslcom-esigner') {
+            $required = @(
+              'SSL_COM_USERNAME',
+              'SSL_COM_PASSWORD',
+              'SSL_COM_CREDENTIAL_ID',
+              'SSL_COM_TOTP_SECRET'
+            )
+            $missing = @($required | Where-Object {
+              [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+            })
+            if ($missing.Count -gt 0) {
+              throw "SSL.com eSigner configuration is incomplete: $($missing -join ', ')"
+            }
           } else {
-            throw 'WINDOWS_SIGNING_PROVIDER must be pfx or azure-artifact-signing for tagged releases'
+            throw 'WINDOWS_SIGNING_PROVIDER must be pfx, azure-artifact-signing, or sslcom-esigner for tagged releases'
           }
       - name: Validate external release acceptance
         if: startsWith(github.ref, 'refs/tags/')
@@ -110,6 +127,21 @@ jobs:
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
+      - name: Sign portable application with SSL.com eSigner
+        if: startsWith(github.ref, 'refs/tags/') && vars.WINDOWS_SIGNING_PROVIDER == 'sslcom-esigner'
+        # Official v1.3.2 action pinned to its verified commit.
+        uses: sslcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b
+        with:
+          command: sign
+          username: ${{ secrets.SSL_COM_USERNAME }}
+          password: ${{ secrets.SSL_COM_PASSWORD }}
+          credential_id: ${{ secrets.SSL_COM_CREDENTIAL_ID }}
+          totp_secret: ${{ secrets.SSL_COM_TOTP_SECRET }}
+          file_path: ${{ steps.portable.outputs.path }}
+          malware_block: true
+          override: true
+          environment_name: PROD
+          clean_logs: true
       - name: Verify and stage release artifact
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ versioning; dates are ISO. Version is sourced from `package.json` and surfaced b
   signing credentials, or an invalid signature and publish a SHA-256 checksum.
 - Tagged Windows releases support Microsoft Artifact Signing through GitHub OIDC
   as the preferred alternative to storing a PFX certificate in GitHub secrets.
+- Tagged Windows releases also support SSL.com eSigner as a cloud-HSM signing
+  provider that does not require an Azure subscription or local hardware token.
 
 ## [1.3.0] — 2026-07-06
 Closing renderer-independent Partials with real code.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -20,6 +20,11 @@ validation artifacts.
 
 Set the repository variable `WINDOWS_SIGNING_PROVIDER` to one of:
 
+- `sslcom-esigner`: uses SSL.com eSigner without Azure or a local hardware
+  token. Store `SSL_COM_USERNAME`, `SSL_COM_PASSWORD`,
+  `SSL_COM_CREDENTIAL_ID`, and `SSL_COM_TOTP_SECRET` as repository secrets.
+  Obtain an organization-validated code-signing certificate with eSigner cloud
+  signing, enable automated signing, and use the production credential ID.
 - `azure-artifact-signing` (preferred): uses Microsoft Artifact Signing with
   GitHub OIDC. Store `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and
   `AZURE_SUBSCRIPTION_ID` as repository secrets. Store
@@ -30,9 +35,10 @@ Set the repository variable `WINDOWS_SIGNING_PROVIDER` to one of:
 - `pfx`: store the base64-encoded certificate in `WINDOWS_CSC_LINK` and its
   password in `WINDOWS_CSC_KEY_PASSWORD` as repository secrets.
 
-Neither route permits an unsigned tagged release. Azure signing uses Microsoft's
-RFC 3161 timestamp service so the signature remains verifiable after the
-short-lived signing certificate expires.
+No route permits an unsigned tagged release. Every provider output is checked
+with `Get-AuthenticodeSignature` before GitHub may publish it. Azure signing
+uses Microsoft's RFC 3161 timestamp service; eSigner signs and timestamps
+through SSL.com's cloud-HSM service.
 
 ## Pre-release Gates
 

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -90,13 +90,17 @@ describe('production readiness regressions', () => {
     const workflow = readFileSync(join(ROOT, '.github/workflows/build.yml'), 'utf8');
     const acceptance = JSON.parse(readFileSync(join(ROOT, 'release-acceptance.json'), 'utf8'));
     const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
-    expect(workflow).toContain('WINDOWS_SIGNING_PROVIDER must be pfx or azure-artifact-signing');
+    expect(workflow).toContain('WINDOWS_SIGNING_PROVIDER must be pfx, azure-artifact-signing, or sslcom-esigner');
     expect(workflow).toContain('WINDOWS_CSC_LINK is required when WINDOWS_SIGNING_PROVIDER=pfx');
     expect(workflow).toContain('Azure Artifact Signing configuration is incomplete');
     expect(workflow).toContain('id-token: write');
     expect(workflow).toContain('uses: azure/login@v3');
     expect(workflow).toContain('uses: azure/artifact-signing-action@v2');
     expect(workflow).toContain('timestamp-rfc3161: http://timestamp.acs.microsoft.com');
+    expect(workflow).toContain('SSL.com eSigner configuration is incomplete');
+    expect(workflow).toContain('uses: sslcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b');
+    expect(workflow).toContain('malware_block: true');
+    expect(workflow).toContain('override: true');
     expect(workflow).toContain("Tag ${{ github.ref_name }} does not match package version");
     expect(workflow).toContain('release-acceptance.mjs --require-approved --tag');
     expect(workflow).toContain("$signature.Status -ne 'Valid'");


### PR DESCRIPTION
## Summary
- add SSL.com eSigner as a non-Azure cloud-HSM signing provider
- pin the official eSigner action to the verified v1.3.2 commit
- validate all required credentials before a tagged build
- sign the exact portable executable in place with malware blocking
- retain independent Authenticode `Valid` verification before publishing

## Verification
- workflow YAML parsed successfully
- focused production-readiness suite: 21 passed
- full gate: 32 files, 220 tests passed

No SSL.com purchase or external account change is made by this PR.