### PR TITLE
Normalize Flask recovery paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ versioning; dates are ISO. Version is sourced from `package.json` and surfaced b
   compact source controls that open the owning document.
 
 ### Fixed
+- Normalized directly supplied Flask recovery paths before containment checks so
+  Windows short/long profile aliases cannot reject evidence inside the same root.
 - Unified direct Flask, launcher, environment-template, and recovery upload-root
   defaults while retaining an existing legacy `instance/laro_uploads` directory.
 - Made direct production preflight load the project environment and fail closed

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ GitHub Actions repeats the Node and browser checks on the supported Node 22 tool
   NOvA parsing/filter, unknown-metric scoring, and review-gated
   media/organization discovery, tenant isolation, case-draft persistence, and
   target-database readiness tests, with no skipped or todo tests.
-- Full Python discovery reported 214 passing tests, including 12 coordinated
+- Full Python discovery reported 215 passing tests, including 13 coordinated
   Flask recovery tests. Warning-focused optimization and UCID tests also passed
   with deprecations promoted to errors.
 - The Vite 8 renderer, Electron 43 main process, and standalone server builds completed successfully.

--- a/flask_recovery.py
+++ b/flask_recovery.py
@@ -53,6 +53,18 @@ def _resolved(path: Path) -> Path:
     return path.expanduser().resolve()
 
 
+def _normalized_config(config: FlaskRecoveryConfig) -> FlaskRecoveryConfig:
+    return FlaskRecoveryConfig(
+        root=_resolved(config.root),
+        ledger_database=_resolved(config.ledger_database),
+        auth_database=_resolved(config.auth_database),
+        upload_root=_resolved(config.upload_root),
+        token_root=_resolved(config.token_root),
+        session_secret=config.session_secret,
+        token_encryption_key=config.token_encryption_key,
+    )
+
+
 def _sqlite_path(value: str, root: Path) -> Path:
     raw = str(value or "").strip()
     if not raw:
@@ -355,6 +367,7 @@ def create_backup_set(
     allow_session_reset: bool = False,
 ) -> Dict[str, Any]:
     destination = _resolved(destination)
+    config = _normalized_config(config)
     _ensure_distinct(config)
     if destination.exists():
         raise RecoveryError(f"Recovery-set destination already exists: {destination}")
@@ -560,6 +573,8 @@ def validate_backup_set(
     allow_session_reset: bool = False,
 ) -> Dict[str, Any]:
     recovery_set = _resolved(recovery_set)
+    if config is not None:
+        config = _normalized_config(config)
     if not recovery_set.is_dir() or recovery_set.is_symlink():
         raise RecoveryError(f"Flask recovery set does not exist: {recovery_set}")
     manifest = _load_manifest(recovery_set)
@@ -639,6 +654,7 @@ def restore_backup_set(
 ) -> RestoreResult:
     if not confirm_stopped:
         raise RecoveryError("Restore requires --confirm-stopped after the Flask runtime has been stopped")
+    config = _normalized_config(config)
     _ensure_distinct(config)
     manifest = validate_backup_set(recovery_set, config, allow_session_reset=allow_session_reset)
     recovery_set = _resolved(recovery_set)

--- a/test_flask_recovery.py
+++ b/test_flask_recovery.py
@@ -338,6 +338,24 @@ class FlaskRecoveryTests(unittest.TestCase):
             config = config_from_environment(root=root)
         self.assertEqual(config.upload_root, (root / "instance" / "uploads").resolve())
 
+    def test_normalizes_direct_config_paths_before_upload_containment_checks(self):
+        canonical = self.root / "normalized-source"
+        alias = canonical / "alias"
+        alias.mkdir(parents=True)
+        unresolved = alias / ".."
+        config = FlaskRecoveryConfig(
+            root=unresolved,
+            ledger_database=unresolved / "instance" / "ledger.sqlite3",
+            auth_database=unresolved / "instance" / "auth.sqlite3",
+            upload_root=unresolved / "instance" / "uploads",
+            token_root=unresolved / "tokens",
+            session_secret=SESSION_SECRET,
+        )
+        self._seed(config)
+        recovery_set = self.root / "normalized-backup"
+        manifest = create_backup_set(recovery_set, config)
+        self.assertEqual(manifest["upload_references"][0]["relative_path"], "case_1/proof.txt")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes the protected-main Windows workflow failure by resolving every directly supplied Flask recovery path at the public API boundary before containment checks. This makes Windows short profile aliases such as RUNNER~1 compare against the same canonical upload root as resolved evidence paths. Adds a regression test with an unresolved path alias. Verified with 215 Python tests, the Flask recovery drill, the production-readiness guard, and the full 51-file/326-test stabilization gate.