### PR TITLE
Compare canonical paths in Flask recovery drill

### DIFF
--- a/scripts/flask_recovery_drill.py
+++ b/scripts/flask_recovery_drill.py
@@ -121,7 +121,7 @@ def main() -> None:
         assert case == ("Verified recovery case",)
         assert user == ("recovery@example.test",)
         assert session == ("bearer-session-hash",)
-        assert Path(local_path) == config.upload_root / "case_41" / "notice.txt"
+        assert Path(local_path).resolve() == (config.upload_root / "case_41" / "notice.txt").resolve()
         assert Path(local_path).read_bytes() == b"Recovery drill legal evidence"
         assert (config.token_root / "google-recovery.vault").read_bytes() == b"encrypted-oauth-record"
         assert restored.previous_ledger.read_bytes() == b"mutated-ledger"

--- a/test_flask_recovery.py
+++ b/test_flask_recovery.py
@@ -355,6 +355,16 @@ class FlaskRecoveryTests(unittest.TestCase):
         recovery_set = self.root / "normalized-backup"
         manifest = create_backup_set(recovery_set, config)
         self.assertEqual(manifest["upload_references"][0]["relative_path"], "case_1/proof.txt")
+        restore_backup_set(recovery_set, config, confirm_stopped=True)
+        ledger = sqlite3.connect(config.ledger_database)
+        try:
+            restored_path = Path(ledger.execute("SELECT local_path FROM case_documents WHERE id = 1").fetchone()[0])
+        finally:
+            ledger.close()
+        self.assertEqual(
+            restored_path.resolve(),
+            (config.upload_root / "case_1" / "proof.txt").resolve(),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the remaining protected-main Windows workflow failure. Backup and restore already succeeded after path normalization; only the drill compared the restored canonical long path against its own short RUNNER~1 spelling. The assertion now resolves both paths, and the alias regression test now performs a full restore and verifies the rebased database path canonically. The focused drill and regression test pass.