### PR TITLE
Port hardened lawyer directory search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ versioning; dates are ISO. Version is sourced from `package.json` and surfaced b
 ## Unreleased
 
 ### Added
+- Added authenticated server-side lawyer directory search and pagination,
+  adapted from the predecessor dashboard after fixing its post-pagination
+  filtering error, with accurate totals, official NOvA-only filtering, stable
+  ordering, and mounted page controls.
 - Added coordinated Flask recovery sets for the legal ledger, authentication
   sessions, encrypted OAuth vault, and uploaded evidence, with stable-source
   checks, manifest inventories, external-secret compatibility binding,

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ GitHub Actions repeats the Node and browser checks on the supported Node 22 tool
 - Server, Electron main-process, and shipped renderer TypeScript checks passed; no shipped runtime module disables type checking; ESLint passed.
 - Traceability reported 116 rows, 91 cited, and 0 broken references.
 - Runtime no-excuses scan reported 0 suspect findings; account safety reported 0 high-severity findings.
-- Vitest reported 51 passing files and 326 passing tests, including controlled
+- Vitest reported 51 passing files and 328 passing tests, including controlled
   NOvA parsing/filter, unknown-metric scoring, and review-gated
   media/organization discovery, tenant isolation, case-draft persistence, and
   target-database readiness tests, with no skipped or todo tests.
@@ -326,6 +326,7 @@ unknown-publisher warning. Optional Store and direct-signing routes remain avail
 - [Operator Runbook](docs/OPERATOR_RUNBOOK.md)
 - [Provider Reality Review](docs/PROVIDERS.md)
 - [Legacy Dashboard Port Audit](docs/LEGACY_DASHBOARD_PORT_AUDIT.md)
+- [Lawyer Automation Dashboards Port Audit](docs/LAWYER_AUTOMATION_DASHBOARDS_PORT_AUDIT.md)
 - [Feature Flags](docs/FEATURE_FLAGS.md)
 - [Deployment](docs/DEPLOYMENT.md)
 - [Backup and Restore](docs/BACKUP_RESTORE.md)

--- a/docs/LAWYER_AUTOMATION_DASHBOARDS_PORT_AUDIT.md
+++ b/docs/LAWYER_AUTOMATION_DASHBOARDS_PORT_AUDIT.md
@@ -1,0 +1,77 @@
+# Lawyer Automation Dashboards Port Audit
+
+Date: 2026-07-20
+
+Source: `Noodzakelijk-Online/lawyer-automation-dashboards` at `9e87b36`
+
+## Conclusion
+
+The source repository is relevant as an earlier prototype and code ancestor, but
+it is not a production-ready replacement for current LARO. Current LARO already
+contains and has hardened most of its useful product surface. Code must be
+selected by behavior and revalidated against LARO's current ownership, provider,
+evidence, and no-fake-success boundaries; wholesale merging is unsafe.
+
+## Measured Overlap
+
+A path-and-SHA comparison of the two checked-out component trees found:
+
+| Measure | Result |
+| --- | ---: |
+| Source component files | 139 |
+| Current LARO component files | 124 |
+| Shared relative paths | 95 |
+| Byte-identical shared files | 31 |
+| Source-only component paths | 44 |
+
+The source-only set is mostly generic UI primitives or unfinished prototypes.
+Examples include billing/quota UI, an annotation canvas whose save callback only
+logs, personalization screens seeded with example lawyers and templates, and a
+sync scheduler whose provider paths are explicitly incomplete.
+
+## Excluded From Port
+
+The following source patterns conflict with current production requirements and
+must not be copied:
+
+- unauthenticated fallback to `demo-user-123`;
+- random analytics and hardcoded example records;
+- provider endpoints that return empty or placeholder success states;
+- OAuth/provider token writes marked as unencrypted;
+- local-file deletion without an ownership check or managed-storage deletion;
+- automatic outreach behavior without LARO's approval, emergency-stop,
+  ownership, provider, audit, and idempotency gates;
+- pricing, quotas, and upgrade prompts that contradict local unmetered operation;
+- the tracked `.env.production` file. No values were copied or printed. Its
+  secret-bearing variable set should be reviewed and any real credentials
+  rotated in the source repository's own security workflow.
+
+## Ported Capability
+
+The useful source concept was server-side lawyer search and pagination. Current
+LARO previously fetched at most 100 rows and filtered that partial set in the
+browser. The source implementation could not be copied directly because it
+filtered legal areas after pagination while reporting the unfiltered total.
+
+The hardened LARO implementation now:
+
+- validates page size, query length, legal area, experience, availability, and
+  official-profile filters at the authenticated tRPC boundary;
+- applies every filter before counting and pagination;
+- handles JSON and legacy text legal-area values;
+- treats SQL wildcard characters in user text literally;
+- excludes malformed experience values from numeric ranges;
+- returns total rows, total pages, and official NOvA record counts;
+- orders official records first and then uses stable name/ID ordering;
+- exposes paged results, truthful counts, loading/error states, and an
+  `Official NOvA only` control in the mounted directory.
+
+Real-database regression coverage proves non-overlapping pages, accurate totals,
+combined filters, literal wildcard handling, malformed experience handling, and
+authentication enforcement.
+
+## Remaining Source Review Rule
+
+Future source-only files are candidates only when a current product requirement
+exists and the implementation can pass LARO's definition of done. File presence
+or prototype documentation is not evidence that a feature is safe or complete.

--- a/server/routers/lawyers.ts
+++ b/server/routers/lawyers.ts
@@ -2,18 +2,116 @@ import { z } from "zod";
 import { adminProcedure, protectedProcedure, router } from "../_core/trpc";
 import { getDb } from "../db";
 import { lawyers as lawyersTable } from '../schema';
+import { and, asc, eq, sql } from "drizzle-orm";
+
+const experienceFilter = z.enum(["0-5", "6-10", "11-20", "20+"]);
+const acceptingFilter = z.enum(["Yes", "Limited", "No", "Unknown"]);
+
+function likePattern(value: string): string {
+  return `%${value.trim().toLowerCase().replace(/[\\%_]/g, "\\$&")}%`;
+}
+
+function experienceCondition(filter: z.infer<typeof experienceFilter>) {
+  const numericYears = sql`CAST(TRIM(${lawyersTable.experienceYears}) AS INTEGER)`;
+  const isNumeric = sql`TRIM(COALESCE(${lawyersTable.experienceYears}, '')) <> ''
+    AND TRIM(${lawyersTable.experienceYears}) NOT GLOB '*[^0-9]*'`;
+
+  if (filter === "0-5") return sql`(${isNumeric}) AND ${numericYears} BETWEEN 0 AND 5`;
+  if (filter === "6-10") return sql`(${isNumeric}) AND ${numericYears} BETWEEN 6 AND 10`;
+  if (filter === "11-20") return sql`(${isNumeric}) AND ${numericYears} BETWEEN 11 AND 20`;
+  return sql`(${isNumeric}) AND ${numericYears} > 20`;
+}
+
+const officialProfileCondition = sql`TRIM(COALESCE(${lawyersTable.officialProfileUrl}, '')) <> ''`;
 
 export const lawyersRouter = router({
   list: protectedProcedure
     .input(z.object({
-      page: z.number().optional().default(1),
-      limit: z.number().optional().default(100),
+      page: z.number().int().min(1).optional().default(1),
+      limit: z.number().int().min(1).max(100).optional().default(24),
+      query: z.string().trim().max(200).optional(),
+      legalArea: z.string().trim().max(120).optional(),
+      experience: experienceFilter.optional(),
+      accepting: acceptingFilter.optional(),
+      officialOnly: z.boolean().optional().default(false),
     }).optional())
     .query(async ({ input }) => {
       const db = await getDb();
-      if (!db) return { lawyers: [] };
-      const results = await db.select().from(lawyersTable).limit(input?.limit || 100).offset(((input?.page || 1) - 1) * (input?.limit || 100));
-      return { lawyers: results };
+      const page = input?.page || 1;
+      const limit = input?.limit || 24;
+      if (!db) {
+        return {
+          lawyers: [],
+          pagination: { total: 0, totalPages: 0, page, limit },
+          officialRecordCount: 0,
+        };
+      }
+
+      const conditions: any[] = [];
+      if (input?.query) {
+        const pattern = likePattern(input.query);
+        conditions.push(sql`(
+          LOWER(COALESCE(${lawyersTable.name}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR LOWER(COALESCE(${lawyersTable.firm}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR LOWER(COALESCE(${lawyersTable.firmName}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR LOWER(COALESCE(${lawyersTable.email}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR LOWER(COALESCE(${lawyersTable.phone}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR LOWER(COALESCE(${lawyersTable.website}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR LOWER(COALESCE(${lawyersTable.address}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR LOWER(COALESCE(${lawyersTable.city}, '')) LIKE ${pattern} ESCAPE '\\'
+          OR LOWER(COALESCE(${lawyersTable.legalAreas}, '')) LIKE ${pattern} ESCAPE '\\'
+        )`);
+      }
+      if (input?.legalArea) {
+        const pattern = likePattern(input.legalArea);
+        conditions.push(sql`(
+          (JSON_VALID(${lawyersTable.legalAreas}) AND EXISTS (
+            SELECT 1
+            FROM JSON_EACH(${lawyersTable.legalAreas}) AS area
+            WHERE LOWER(CAST(area.value AS TEXT)) LIKE ${pattern} ESCAPE '\\'
+          ))
+          OR (NOT JSON_VALID(${lawyersTable.legalAreas})
+            AND LOWER(COALESCE(${lawyersTable.legalAreas}, '')) LIKE ${pattern} ESCAPE '\\')
+        )`);
+      }
+      if (input?.experience) conditions.push(experienceCondition(input.experience));
+      if (input?.accepting) conditions.push(eq(lawyersTable.currentlyAccepting, input.accepting));
+      if (input?.officialOnly) conditions.push(officialProfileCondition);
+
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+      const offset = (page - 1) * limit;
+      const results = await db
+        .select()
+        .from(lawyersTable)
+        .where(where)
+        .orderBy(
+          sql`CASE WHEN ${officialProfileCondition} THEN 0 ELSE 1 END`,
+          asc(lawyersTable.name),
+          asc(lawyersTable.id),
+        )
+        .limit(limit)
+        .offset(offset);
+
+      const totalRows = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(lawyersTable)
+        .where(where);
+      const officialRows = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(lawyersTable)
+        .where(where ? and(where, officialProfileCondition) : officialProfileCondition);
+      const total = Number(totalRows[0]?.count || 0);
+
+      return {
+        lawyers: results,
+        pagination: {
+          total,
+          totalPages: Math.ceil(total / limit),
+          page,
+          limit,
+        },
+        officialRecordCount: Number(officialRows[0]?.count || 0),
+      };
     }),
 
   byId: protectedProcedure

--- a/src/renderer/components/Lawyers.tsx
+++ b/src/renderer/components/Lawyers.tsx
@@ -3,22 +3,39 @@ import DashboardLayout from "@/components/DashboardLayout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Search, Mail, Phone, Globe, MapPin, Users, GitCompare, ExternalLink, Database } from "lucide-react";
+import { Search, Mail, Phone, Globe, MapPin, Users, GitCompare, ExternalLink, Database, ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import { useState } from "react";
 import LawyerComparisonView from "@/components/LawyerComparison";
 import SmartSearchFilters from "@/components/SmartSearchFilters";
 import { useLocation } from "wouter";
 
 export function LawyersDirectoryContent({ embedded = false }: { embedded?: boolean }) {
-  const { data, isLoading } = trpc.lawyers.list.useQuery();
   const [, setLocation] = useLocation();
   const [searchQuery, setSearchQuery] = useState("");
   const [filterLegalArea, setFilterLegalArea] = useState("");
   const [filterExperience, setFilterExperience] = useState("");
   const [filterAccepting, setFilterAccepting] = useState("");
+  const [officialOnly, setOfficialOnly] = useState(false);
+  const [page, setPage] = useState(1);
   const [comparisonMode, setComparisonMode] = useState(false);
   const [selectedLawyers, setSelectedLawyers] = useState<any[]>([]);
+  const pageSize = 24;
+
+  const { data, isLoading, isFetching, error } = trpc.lawyers.list.useQuery({
+    page,
+    limit: pageSize,
+    query: searchQuery.trim() || undefined,
+    legalArea: filterLegalArea.trim() || undefined,
+    experience: filterExperience
+      ? filterExperience as "0-5" | "6-10" | "11-20" | "20+"
+      : undefined,
+    accepting: filterAccepting
+      ? filterAccepting as "Yes" | "Limited" | "No" | "Unknown"
+      : undefined,
+    officialOnly,
+  });
 
   const parseStringArray = (value: unknown): string[] => {
     if (Array.isArray(value)) return value.map(String).filter(Boolean);
@@ -50,43 +67,9 @@ export function LawyersDirectoryContent({ embedded = false }: { embedded?: boole
   };
 
   const lawyers = data?.lawyers || [];
-  const officialRecordCount = lawyers.filter((lawyer: any) => Boolean(lawyer.officialProfileUrl)).length;
-  
-  const filteredLawyers = lawyers.filter((lawyer: any) => {
-    const areas = parseStringArray(lawyer.legalAreas);
-    const normalizedQuery = searchQuery.trim().toLowerCase();
-    // Search filter
-    const matchesSearch = !normalizedQuery || [
-      lawyer.name,
-      lawyer.firm,
-      lawyer.email,
-      lawyer.phone,
-      lawyer.website,
-      lawyer.address,
-      ...areas,
-    ].some((value) => String(value ?? "").toLowerCase().includes(normalizedQuery));
-    
-    // Legal area filter
-    const matchesLegalArea = !filterLegalArea || (() => {
-      return areas.some((area) => area.toLowerCase().includes(filterLegalArea.toLowerCase()));
-    })();
-    
-    // Experience filter
-    const matchesExperience = !filterExperience || (() => {
-      const years = parseInt(lawyer.experienceYears || "0");
-      if (filterExperience === "0-5") return years >= 0 && years <= 5;
-      if (filterExperience === "6-10") return years >= 6 && years <= 10;
-      if (filterExperience === "11-20") return years >= 11 && years <= 20;
-      if (filterExperience === "20+") return years > 20;
-      return true;
-    })();
-    
-    // Accepting cases filter
-    const matchesAccepting = !filterAccepting || 
-      lawyer.currentlyAccepting === filterAccepting;
-    
-    return matchesSearch && matchesLegalArea && matchesExperience && matchesAccepting;
-  });
+  const pagination = data?.pagination || { total: 0, totalPages: 0, page, limit: pageSize };
+  const firstResult = pagination.total === 0 ? 0 : (pagination.page - 1) * pagination.limit + 1;
+  const lastResult = Math.min(pagination.page * pagination.limit, pagination.total);
 
   return (
       <div className={embedded ? "space-y-6" : "p-8 space-y-8"}>
@@ -117,26 +100,43 @@ export function LawyersDirectoryContent({ embedded = false }: { embedded?: boole
                     setFilterExperience(filters.experience || "");
                     setFilterAccepting(filters.accepting || "");
                   }
+                  setPage(1);
                 }}
               />
             </div>
-            <Button 
-              variant={comparisonMode ? "default" : "outline"}
-              className={comparisonMode ? "bg-purple-600 hover:bg-purple-700" : "border-purple-500/30 hover:bg-purple-500/10 hover:border-purple-500/50"}
-              onClick={() => {
-                setComparisonMode(!comparisonMode);
-                if (comparisonMode) setSelectedLawyers([]);
-              }}
-            >
-              <GitCompare className="w-4 h-4 mr-2" />
-              {comparisonMode ? `Compare (${selectedLawyers.length}/3)` : "Compare Mode"}
-            </Button>
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex min-h-10 items-center gap-2 rounded-md border border-border/60 px-3 text-sm">
+                <Checkbox
+                  aria-label="Official NOvA only"
+                  checked={officialOnly}
+                  onCheckedChange={(checked) => {
+                    setOfficialOnly(checked === true);
+                    setPage(1);
+                  }}
+                />
+                Official NOvA only
+              </label>
+              <Button
+                variant={comparisonMode ? "default" : "outline"}
+                className={comparisonMode ? "bg-purple-600 hover:bg-purple-700" : "border-purple-500/30 hover:bg-purple-500/10 hover:border-purple-500/50"}
+                onClick={() => {
+                  setComparisonMode(!comparisonMode);
+                  if (comparisonMode) setSelectedLawyers([]);
+                }}
+              >
+                <GitCompare className="w-4 h-4 mr-2" />
+                {comparisonMode ? `Compare (${selectedLawyers.length}/3)` : "Compare Mode"}
+              </Button>
+            </div>
           </div>
 
           {/* Results Count */}
-          <div className="text-sm text-muted-foreground">
-            Showing {filteredLawyers.length} of {lawyers.length} lawyers
-            {officialRecordCount > 0 && `; ${officialRecordCount} linked to an official NOvA profile`}
+          <div className="flex min-h-5 items-center gap-2 text-sm text-muted-foreground" aria-live="polite">
+            <span>
+              Showing {firstResult}-{lastResult} of {pagination.total} lawyers
+              {(data?.officialRecordCount || 0) > 0 && `; ${data?.officialRecordCount} linked to an official NOvA profile`}
+            </span>
+            {isFetching && !isLoading && <Loader2 className="h-4 w-4 animate-spin" aria-label="Updating lawyer results" />}
           </div>
         </div>
 
@@ -146,7 +146,11 @@ export function LawyersDirectoryContent({ embedded = false }: { embedded?: boole
         )}
 
         {/* Lawyers Grid */}
-        {isLoading ? (
+        {error ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+            Lawyer records could not be loaded: {error.message}
+          </div>
+        ) : isLoading ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {[1, 2, 3, 4, 5, 6].map((i) => (
               <Skeleton key={i} className="h-96 w-full bg-card/50" />
@@ -154,7 +158,7 @@ export function LawyersDirectoryContent({ embedded = false }: { embedded?: boole
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredLawyers?.map((lawyer: any) => {
+            {lawyers.map((lawyer: any) => {
               const legalAreas = parseStringArray(lawyer.legalAreas);
               const languages = parseStringArray(lawyer.languages);
               
@@ -299,13 +303,39 @@ export function LawyersDirectoryContent({ embedded = false }: { embedded?: boole
           </div>
         )}
 
-        {filteredLawyers && filteredLawyers.length === 0 && (
+        {!error && !isLoading && lawyers.length === 0 && (
           <div className="text-center py-12">
             <div className="w-16 h-16 rounded-full bg-purple-500/10 flex items-center justify-center mx-auto mb-4">
               <Search className="w-8 h-8 text-purple-500" />
             </div>
             <p className="text-muted-foreground">No lawyers found matching your search.</p>
           </div>
+        )}
+
+        {!error && pagination.totalPages > 1 && (
+          <nav className="flex items-center justify-center gap-3" aria-label="Lawyer result pages">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={pagination.page <= 1 || isFetching}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+            >
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              Previous
+            </Button>
+            <span className="min-w-28 text-center text-sm text-muted-foreground">
+              Page {pagination.page} of {pagination.totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={pagination.page >= pagination.totalPages || isFetching}
+              onClick={() => setPage((current) => Math.min(pagination.totalPages, current + 1))}
+            >
+              Next
+              <ChevronRight className="ml-1 h-4 w-4" />
+            </Button>
+          </nav>
         )}
       </div>
   );

--- a/src/renderer/components/SmartSearchFilters.tsx
+++ b/src/renderer/components/SmartSearchFilters.tsx
@@ -352,7 +352,7 @@ export default function SmartSearchFilters({
           </div>
           <p className="text-xs text-muted-foreground">
             {searchType === "lawyers"
-              ? "Search checks the loaded directory by name, firm, contact details, address, and legal areas."
+              ? "Search checks the full persisted directory by name, firm, contact details, address, and legal areas."
               : "Keyword match runs on every search. With 2+ characters, LARO can expand natural-language queries using your configured AI provider."}
           </p>
         </CardContent>

--- a/tests/backend/phase051_060.test.ts
+++ b/tests/backend/phase051_060.test.ts
@@ -55,6 +55,72 @@ suite('Phases 051–060 — services', () => {
     expect(search.cases.length).toBeGreaterThan(0);
   });
 
+  it('ports lawyer directory filtering with accurate totals before pagination', async () => {
+    await app.db.insert(app.schema.lawyers).values([
+      buildLawyer({
+        id: 'LWDIR1',
+        name: 'Ada Directory',
+        legalAreas: JSON.stringify(['Port Audit Employment']),
+        experienceYears: '12',
+        currentlyAccepting: 'Yes',
+        officialProfileUrl: 'https://zoekeenadvocaat.advocatenorde.nl/advocaten/ada',
+      }),
+      buildLawyer({
+        id: 'LWDIR2',
+        name: 'Bram Directory',
+        legalAreas: JSON.stringify(['Port Audit Employment']),
+        experienceYears: '3',
+        currentlyAccepting: 'Limited',
+        officialProfileUrl: null,
+      }),
+      buildLawyer({
+        id: 'LWDIR3',
+        name: 'Cato Directory',
+        legalAreas: JSON.stringify(['Port Audit Employment']),
+        experienceYears: '25',
+        currentlyAccepting: 'No',
+        officialProfileUrl: 'https://zoekeenadvocaat.advocatenorde.nl/advocaten/cato',
+      }),
+      buildLawyer({
+        id: 'LWDIR4',
+        name: 'Percent % Specialist',
+        legalAreas: 'Tax Law',
+        experienceYears: 'unknown',
+      }),
+    ] as any);
+
+    const caller = app.makeCaller(U);
+    const first = await caller.lawyers.list({ legalArea: 'Port Audit Employment', page: 1, limit: 2 });
+    const second = await caller.lawyers.list({ legalArea: 'Port Audit Employment', page: 2, limit: 2 });
+
+    expect(first.pagination).toMatchObject({ total: 3, totalPages: 2, page: 1, limit: 2 });
+    expect(first.officialRecordCount).toBe(2);
+    expect(first.lawyers).toHaveLength(2);
+    expect(second.lawyers).toHaveLength(1);
+    expect(new Set([...first.lawyers, ...second.lawyers].map((lawyer: any) => lawyer.id)).size).toBe(3);
+
+    const precise = await caller.lawyers.list({
+      query: 'Ada',
+      experience: '11-20',
+      accepting: 'Yes',
+      officialOnly: true,
+    });
+    expect(precise.pagination.total).toBe(1);
+    expect(precise.lawyers[0]?.id).toBe('LWDIR1');
+
+    const literalWildcard = await caller.lawyers.list({ query: '%' });
+    expect(literalWildcard.pagination.total).toBe(1);
+    expect(literalWildcard.lawyers[0]?.id).toBe('LWDIR4');
+
+    const numericExperience = await caller.lawyers.list({ experience: '0-5' });
+    expect(numericExperience.lawyers.some((lawyer: any) => lawyer.id === 'LWDIR4')).toBe(false);
+  });
+
+  it('keeps the lawyer directory behind authentication', async () => {
+    const anonymous = app.makeCaller(null);
+    await expect(anonymous.lawyers.list({ page: 1, limit: 10 })).rejects.toBeTruthy();
+  });
+
   it('Phase 059 — cases.update rejects an illegal status transition', async () => {
     const caller = app.makeCaller(U);
     const created = await app.db.insert(app.schema.cases).values({


### PR DESCRIPTION
## What changed
- ports the useful lawyer-directory pagination concept from `Noodzakelijk-Online/lawyer-automation-dashboards`
- moves search and every directory filter to the authenticated server boundary before counting and pagination
- adds accurate totals, stable ordering, official NOvA-only filtering, UI pagination, loading/error states, and accessible controls
- documents the measured repository overlap and the prototype patterns deliberately excluded from LARO

## Why
LARO previously fetched at most 100 lawyers and filtered only that partial browser-side set. The source prototype suggested server pagination, but its implementation filtered legal areas after pagination and returned an incorrect total. This PR ports the behavior after correcting that defect and retaining LARO's production safety boundaries.

## Validation
- `npm.cmd run gate` (51 files, 328 tests; all blocking stabilization gates passed)
- `npm.cmd run test:a11y:browser` (all supported desktop/mobile routes passed)
- `npx.cmd vitest run tests/backend/phase051_060.test.ts` (10 passed)
- `npm.cmd run typecheck:renderer`
- `npm.cmd audit --omit=dev --audit-level=moderate` (0 vulnerabilities)
- manual browser QA for pagination, NOvA-only filtering, search, responsive fit, and console errors