### PR TITLE
Add durable provider acceptance audit evidence

### DIFF
--- a/docs/NO_EXCUSES_SEARCH.md
+++ b/docs/NO_EXCUSES_SEARCH.md
@@ -27,7 +27,7 @@ Descriptive words (mock/stub/placeholder/fake) needing human judgement. Triage o
 | `server/outreachSend.ts` | 16 | `* The email sender is injectable so tests exercise the full path with a fake` |
 | `server/outreachSend.ts` | 48 | `* `sender` is injectable (tests pass a fake); production uses systemEmail.` |
 | `server/routers/cases.ts` | 146 | `// empty GDPR stub.` |
-| `server/routers/enhancedConnections.ts` | 101 | `// Honest unavailability — no fake auth URL.` |
+| `server/routers/enhancedConnections.ts` | 102 | `// Honest unavailability — no fake auth URL.` |
 | `server/routers/extendedRouters.ts` | 6 | `* run. No fake success (Phase 014).` |
 | `server/routers/extendedRouters.ts` | 211 | `// provider is configured there is nothing to sync (honest, not a fake OK).` |
 | `server/routers/index.ts` | 359 | `// stub): computes genuine clarifications the user must resolve BEFORE outreach` |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -103,6 +103,17 @@ with `status: "passed"`, a non-future `testedAt` timestamp, evidence references,
 and every mandatory check reported by `npm run release:check`. Generic approval
 notes and credential-presence screenshots are not sufficient.
 
+For the Google acceptance run, use LARO's owner-scoped audit history to retain
+the event IDs and timestamps for `provider.connected`,
+`evidence.source_opened`, and `provider.disconnect_revoked`. The final event is
+written only after Google returns a successful revocation or confirms that the
+grant is already invalid. `provider.disconnect_failed` proves only a failed
+attempt and explicitly records that local credentials were retained for retry;
+it cannot satisfy `disconnectRevoked`. Audit details intentionally exclude
+tokens, account email addresses, document URLs, and document contents. These
+events are supporting evidence only and never approve a release gate by
+themselves.
+
 ## Canary
 
 Risky behavior ships disabled. In particular, `outreach.send.enabled` defaults

--- a/server/audit.ts
+++ b/server/audit.ts
@@ -91,9 +91,16 @@ export const AUDIT_ACTIONS = {
   EMAIL_SENT: "email.sent",
   EMAIL_RESPONSE_RECEIVED: "email.response_received",
 
+  // Provider connection actions
+  PROVIDER_CONNECTED: "provider.connected",
+  PROVIDER_DISCONNECTED: "provider.disconnected",
+  PROVIDER_DISCONNECT_REVOKED: "provider.disconnect_revoked",
+  PROVIDER_DISCONNECT_FAILED: "provider.disconnect_failed",
+
   // Evidence actions
   EVIDENCE_EXPORTED: "evidence.exported",
   EVIDENCE_SCORED: "evidence.scored",
+  EVIDENCE_SOURCE_OPENED: "evidence.source_opened",
   
   // Outreach actions
   OUTREACH_INITIATED: "outreach.initiated",

--- a/server/emailOAuth.ts
+++ b/server/emailOAuth.ts
@@ -24,7 +24,9 @@ export function decryptToken(text: string): string {
  * Revoke a Google OAuth grant. Google returns HTTP 400 when the supplied token
  * is already invalid, which is a safe terminal state for a disconnect request.
  */
-export async function revokeGoogleToken(token: string): Promise<void> {
+export type GoogleRevocationOutcome = 'revoked' | 'already_invalid' | 'not_applicable';
+
+export async function revokeGoogleToken(token: string): Promise<Exclude<GoogleRevocationOutcome, 'not_applicable'>> {
   if (!token) {
     throw new Error('Google token is unavailable for revocation');
   }
@@ -39,21 +41,23 @@ export async function revokeGoogleToken(token: string): Promise<void> {
   if (!response.ok && response.status !== 400) {
     throw new Error(`Google token revocation failed (HTTP ${response.status})`);
   }
+
+  return response.status === 400 ? 'already_invalid' : 'revoked';
 }
 
 /** Revoke the refresh token when present; it represents the durable grant. */
 export async function revokeStoredGoogleTokens(tokens: {
   accessToken?: string | null;
   refreshToken?: string | null;
-}): Promise<void> {
+}): Promise<GoogleRevocationOutcome> {
   const encryptedToken = tokens.refreshToken || tokens.accessToken;
-  if (!encryptedToken) return;
+  if (!encryptedToken) return 'not_applicable';
 
   const token = decryptToken(encryptedToken);
   if (!token) {
     throw new Error('Stored Google token could not be decrypted');
   }
-  await revokeGoogleToken(token);
+  return revokeGoogleToken(token);
 }
 
 /**

--- a/server/oauth2.ts
+++ b/server/oauth2.ts
@@ -6,6 +6,7 @@ import { nanoid } from "nanoid";
 import crypto from "crypto";
 import { encryptToken, decryptToken } from "./emailOAuth";
 import { ENV } from "./_core/env";
+import { AUDIT_ACTIONS, createAuditLog } from "./audit";
 
 export interface OAuth2Config {
   clientId: string;
@@ -19,6 +20,7 @@ export interface OAuth2Tokens {
   refreshToken?: string;
   expiresIn: number; // seconds
   tokenType: string;
+  scope?: string;
 }
 
 export interface EmailAccountInfo {
@@ -239,6 +241,7 @@ export async function exchangeCodeForTokens(
       refreshToken: data.refresh_token,
       expiresIn: Number(data.expires_in) || 3600,
       tokenType: data.token_type || "Bearer",
+      scope: data.scope,
     };
   }
 
@@ -267,6 +270,7 @@ export async function exchangeCodeForTokens(
     refreshToken: data.refresh_token,
     expiresIn: Number(data.expires_in) || 3600,
     tokenType: data.token_type || "Bearer",
+    scope: data.scope,
   };
 }
 
@@ -300,14 +304,18 @@ export async function saveEmailAccount(
   provider: "gmail" | "outlook",
   tokens: OAuth2Tokens,
   accountInfo: EmailAccountInfo
-): Promise<void> {
+): Promise<string> {
   const db = await getDb();
   if (!db) throw new Error("Database not available");
 
   const existing = await db
     .select()
     .from(emailAccounts)
-    .where(and(eq(emailAccounts.userId, userId), eq(emailAccounts.email, accountInfo.email)))
+    .where(and(
+      eq(emailAccounts.userId, userId),
+      eq(emailAccounts.provider, provider),
+      eq(emailAccounts.email, accountInfo.email),
+    ))
     .limit(1);
 
   const row = {
@@ -328,11 +336,27 @@ export async function saveEmailAccount(
     updatedAt: new Date(),
   };
 
+  const accountId = existing[0]?.id ?? nanoid();
   if (existing[0]) {
     await db.update(emailAccounts).set(row).where(eq(emailAccounts.id, existing[0].id));
   } else {
-    await db.insert(emailAccounts).values({ id: nanoid(), ...row, createdAt: new Date() });
+    await db.insert(emailAccounts).values({ id: accountId, ...row, createdAt: new Date() });
   }
+
+  await createAuditLog({
+    userId,
+    action: AUDIT_ACTIONS.PROVIDER_CONNECTED,
+    entityType: "provider_connection",
+    entityId: accountId,
+    details: {
+      provider: provider === "gmail" ? "google" : "microsoft",
+      requestedScopes: getOAuth2Config(provider).scopes,
+      tokenReportedScopes: tokens.scope ? tokens.scope.split(/\s+/).filter(Boolean) : [],
+      refreshGrantStored: Boolean(tokens.refreshToken),
+    },
+  });
+
+  return accountId;
 }
 
 export async function refreshAccessToken(
@@ -363,6 +387,7 @@ export async function refreshAccessToken(
       refreshToken: data.refresh_token || refreshToken,
       expiresIn: Number(data.expires_in) || 3600,
       tokenType: data.token_type || "Bearer",
+      scope: data.scope,
     };
   }
 
@@ -387,5 +412,6 @@ export async function refreshAccessToken(
     refreshToken: data.refresh_token || refreshToken,
     expiresIn: Number(data.expires_in) || 3600,
     tokenType: data.token_type || "Bearer",
+    scope: data.scope,
   };
 }

--- a/server/routers/emailAccounts.ts
+++ b/server/routers/emailAccounts.ts
@@ -10,9 +10,10 @@ import {
   getAccountInfo,
   refreshAccessToken,
   consumeOAuthState,
+  saveEmailAccount,
 } from "../oauth2";
-import crypto from "crypto";
 import { encryptToken, decryptToken, revokeStoredGoogleTokens } from "../emailOAuth";
+import { AUDIT_ACTIONS, createAuditLog } from "../audit";
 
 export const emailAccountsRouter = router({
   getAuthUrl: protectedProcedure
@@ -38,21 +39,7 @@ export const emailAccountsRouter = router({
       const tokens = await exchangeCodeForTokens(input.provider, input.code, state.codeVerifier);
       const accountInfo = await getAccountInfo(input.provider, tokens.accessToken);
 
-      const id = crypto.randomBytes(16).toString("hex");
-      const accessEnc = encryptToken(tokens.accessToken);
-      const refreshEnc = tokens.refreshToken ? encryptToken(tokens.refreshToken) : null;
-
-      await db.insert(emailAccounts).values({
-        id,
-        userId: ctx.user.id,
-        provider: input.provider,
-        email: accountInfo.email,
-        accessToken: accessEnc,
-        refreshToken: refreshEnc,
-        status: "connected",
-        connectedAt: new Date(),
-        tokenExpiry: new Date(Date.now() + (tokens.expiresIn || 3600) * 1000),
-      });
+      const id = await saveEmailAccount(ctx.user.id, input.provider, tokens, accountInfo);
 
       return { success: true as const, accountId: id, email: accountInfo.email };
     }),
@@ -111,10 +98,23 @@ export const emailAccountsRouter = router({
         .where(and(eq(emailAccounts.id, input.accountId), eq(emailAccounts.userId, ctx.user.id)))
         .limit(1);
       if (!acc) throw new Error("Not found");
+      let revocationOutcome = "not_applicable";
       if (acc.provider === "gmail") {
         try {
-          await revokeStoredGoogleTokens(acc);
+          revocationOutcome = await revokeStoredGoogleTokens(acc);
         } catch (error) {
+          await createAuditLog({
+            userId: ctx.user.id,
+            action: AUDIT_ACTIONS.PROVIDER_DISCONNECT_FAILED,
+            entityType: "provider_connection",
+            entityId: acc.id,
+            details: {
+              provider: "google",
+              route: "emailAccounts.revoke",
+              reason: "upstream_revocation_failed",
+              localStateRetained: true,
+            },
+          });
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
             message: "Google did not confirm token revocation; the local connection was retained so disconnect can be retried.",
@@ -123,6 +123,21 @@ export const emailAccountsRouter = router({
         }
       }
       await db.delete(emailAccounts).where(eq(emailAccounts.id, acc.id));
+      const revocationConfirmed = revocationOutcome === "revoked" || revocationOutcome === "already_invalid";
+      await createAuditLog({
+        userId: ctx.user.id,
+        action: revocationConfirmed
+          ? AUDIT_ACTIONS.PROVIDER_DISCONNECT_REVOKED
+          : AUDIT_ACTIONS.PROVIDER_DISCONNECTED,
+        entityType: "provider_connection",
+        entityId: acc.id,
+        details: {
+          provider: acc.provider === "gmail" ? "google" : acc.provider,
+          route: "emailAccounts.revoke",
+          revocationOutcome,
+          localCredentialsRemoved: true,
+        },
+      });
       return { success: true as const };
     }),
 

--- a/server/routers/enhancedConnections.ts
+++ b/server/routers/enhancedConnections.ts
@@ -7,6 +7,7 @@ import { ENV } from '../_core/env';
 import { beginOAuthFlow } from '../oauth2';
 import { revokeStoredGoogleTokens } from '../emailOAuth';
 import { TRPCError } from '@trpc/server';
+import { AUDIT_ACTIONS, createAuditLog } from '../audit';
 
 /**
  * Phase 012 — external provider reality review.
@@ -126,12 +127,26 @@ const createEnhancedConnectionRouter = (providerName: string) => {
               const accounts = await db.select().from(emailAccounts).where(
                 and(eq(emailAccounts.userId, ctx.user.id), eq(emailAccounts.provider, oauthProvider))
               );
+              const revocationOutcomes: string[] = [];
               if (oauthProvider === 'gmail') {
                 try {
                   for (const account of accounts) {
-                    await revokeStoredGoogleTokens(account);
+                    revocationOutcomes.push(await revokeStoredGoogleTokens(account));
                   }
                 } catch (error) {
+                  await createAuditLog({
+                    userId: ctx.user.id,
+                    action: AUDIT_ACTIONS.PROVIDER_DISCONNECT_FAILED,
+                    entityType: 'provider_connection',
+                    entityId: 'google',
+                    details: {
+                      provider: 'google',
+                      route: `${providerName}.disconnect`,
+                      accountCount: accounts.length,
+                      reason: 'upstream_revocation_failed',
+                      localStateRetained: true,
+                    },
+                  });
                   throw new TRPCError({
                     code: 'PRECONDITION_FAILED',
                     message: 'Google did not confirm token revocation; the local connection was retained so disconnect can be retried.',
@@ -151,6 +166,25 @@ const createEnhancedConnectionRouter = (providerName: string) => {
                   inArray(evidenceSources.sourceType, sharedSources),
                 )
               );
+              const revocationConfirmed = revocationOutcomes.some(
+                (outcome) => outcome === 'revoked' || outcome === 'already_invalid'
+              );
+              await createAuditLog({
+                userId: ctx.user.id,
+                action: revocationConfirmed
+                  ? AUDIT_ACTIONS.PROVIDER_DISCONNECT_REVOKED
+                  : AUDIT_ACTIONS.PROVIDER_DISCONNECTED,
+                entityType: 'provider_connection',
+                entityId: oauthProvider === 'gmail' ? 'google' : oauthProvider,
+                details: {
+                  provider: oauthProvider === 'gmail' ? 'google' : oauthProvider,
+                  route: `${providerName}.disconnect`,
+                  accountCount: accounts.length,
+                  revocationOutcomes: oauthProvider === 'gmail' ? revocationOutcomes : ['not_applicable'],
+                  localCredentialsRemoved: true,
+                  localSourcesRemoved: true,
+                },
+              });
               return { success: true };
             }
             await db.delete(evidenceSources).where(

--- a/server/routers/evidenceFiles.ts
+++ b/server/routers/evidenceFiles.ts
@@ -21,6 +21,7 @@ import {
   MAX_EVIDENCE_FILE_BYTES,
 } from "../../shared/evidenceFiles";
 import { TRPCError } from "@trpc/server";
+import { AUDIT_ACTIONS, createAuditLog } from "../audit";
 
 export const evidenceFilesRouter = router({
 
@@ -171,20 +172,37 @@ export const evidenceFilesRouter = router({
       const file = await getEvidenceFile(userId, input.id);
       if (!file) throw new Error("File not found");
 
-      if (typeof file.metadata === "string") {
-        try {
-          const storageKey = JSON.parse(file.metadata)?.storageKey;
-          if (typeof storageKey === "string" && storageKey) {
-            return { url: await storageGet(storageKey) };
-          }
-        } catch {
-          // Fall through to a legacy URL when metadata is not managed storage.
-        }
-      }
+      const storageKey = managedStorageKeyFromMetadata(file.metadata);
+      if (storageKey) return { url: await storageGet(storageKey) };
 
       if ((file as any).fileUrl) return { url: (file as any).fileUrl };
 
       return { url: null, message: "File not available for download" };
+    }),
+
+  // Record only after the renderer successfully dispatches the source URL.
+  recordSourceOpened: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const file = await getEvidenceFile(ctx.user.id, input.id);
+      if (!file) throw new Error("File not found");
+      const managed = Boolean(managedStorageKeyFromMetadata(file.metadata));
+      if (!managed && !(file as any).fileUrl) {
+        throw new Error("File not available for download");
+      }
+
+      await createAuditLog({
+        userId: ctx.user.id,
+        action: AUDIT_ACTIONS.EVIDENCE_SOURCE_OPENED,
+        entityType: "evidence",
+        entityId: file.id,
+        details: {
+          caseId: file.caseId,
+          accessMethod: managed ? "managed_storage" : "source_url",
+          dispatchConfirmed: true,
+        },
+      });
+      return { success: true as const };
     }),
 
   // Also search evidence_files table (desktop scanner uploads go here)

--- a/server/routers/googleDrive.ts
+++ b/server/routers/googleDrive.ts
@@ -17,6 +17,7 @@ import { createEvidenceFile } from "../evidence";
 import { analyzeStoredEvidence } from "../documentAnalysisService";
 import { supportsDocumentAnalysisMime } from "../documentIntelligence";
 import { revokeStoredGoogleTokens } from "../emailOAuth";
+import { AUDIT_ACTIONS, createAuditLog } from "../audit";
 
 async function ingestDriveEvidence(options: {
   userId: string;
@@ -138,11 +139,25 @@ export const googleDriveRouter = router({
       const accounts = await db.select().from(emailAccounts).where(
         and(eq(emailAccounts.userId, ctx.user.id), eq(emailAccounts.provider, "gmail"))
       );
+      const revocationOutcomes: string[] = [];
       try {
         for (const account of accounts) {
-          await revokeStoredGoogleTokens(account);
+          revocationOutcomes.push(await revokeStoredGoogleTokens(account));
         }
       } catch (error) {
+        await createAuditLog({
+          userId: ctx.user.id,
+          action: AUDIT_ACTIONS.PROVIDER_DISCONNECT_FAILED,
+          entityType: "provider_connection",
+          entityId: "google",
+          details: {
+            provider: "google",
+            route: "googleDrive.disconnect",
+            accountCount: accounts.length,
+            reason: "upstream_revocation_failed",
+            localStateRetained: true,
+          },
+        });
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
           message: "Google did not confirm token revocation; the local connection was retained so disconnect can be retried.",
@@ -153,6 +168,24 @@ export const googleDriveRouter = router({
       await db
         .delete(emailAccounts)
         .where(and(eq(emailAccounts.userId, ctx.user.id), eq(emailAccounts.provider, "gmail")));
+      const revocationConfirmed = revocationOutcomes.some(
+        (outcome) => outcome === "revoked" || outcome === "already_invalid"
+      );
+      await createAuditLog({
+        userId: ctx.user.id,
+        action: revocationConfirmed
+          ? AUDIT_ACTIONS.PROVIDER_DISCONNECT_REVOKED
+          : AUDIT_ACTIONS.PROVIDER_DISCONNECTED,
+        entityType: "provider_connection",
+        entityId: "google",
+        details: {
+          provider: "google",
+          route: "googleDrive.disconnect",
+          accountCount: accounts.length,
+          revocationOutcomes,
+          localCredentialsRemoved: true,
+        },
+      });
       return { success: true };
     }),
 

--- a/src/renderer/components/CaseTimeline.tsx
+++ b/src/renderer/components/CaseTimeline.tsx
@@ -50,6 +50,7 @@ export function CaseTimeline({ caseId }: CaseTimelineProps) {
 
   const generateMutation = trpc.documentAnalysis.generateCaseTimeline.useMutation();
   const sourceMutation = trpc.evidenceFiles.getDownloadUrl.useMutation();
+  const sourceOpenedMutation = trpc.evidenceFiles.recordSourceOpened.useMutation();
 
   const handleGenerateTimeline = async () => {
     try {
@@ -71,6 +72,7 @@ export function CaseTimeline({ caseId }: CaseTimelineProps) {
       const source = await sourceMutation.mutateAsync({ id: evidenceId });
       if (!source.url) throw new Error(source.message || "The source file is not available.");
       await getElectronAPI().openExternal(source.url);
+      await sourceOpenedMutation.mutateAsync({ id: evidenceId });
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "The source file could not be opened.");
     }

--- a/tests/backend/phase061_070.test.ts
+++ b/tests/backend/phase061_070.test.ts
@@ -4,8 +4,9 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { and, eq, inArray } from 'drizzle-orm';
 import { bootTestApp, sqliteAvailable, type TestApp } from '../helpers/app';
-import { buildUser, buildLawyer } from '../factories';
+import { buildUser, buildLawyer, buildCase, buildEvidence } from '../factories';
 import { encryptToken } from '../../server/emailOAuth';
+import { saveEmailAccount } from '../../server/oauth2';
 
 const suite = sqliteAvailable ? describe : describe.skip;
 
@@ -89,6 +90,29 @@ suite('Phases 061–070', () => {
     expect(ownLocalSources).toHaveLength(1);
     expect(otherAccounts).toHaveLength(1);
     expect(otherSources).toHaveLength(1);
+
+    const [audit] = await app.db.select().from(app.schema.auditLogs)
+      .where(and(
+        eq(app.schema.auditLogs.userId, U.id),
+        eq(app.schema.auditLogs.action, 'provider.disconnect_revoked'),
+      ));
+    expect(audit).toBeTruthy();
+    expect(JSON.parse(audit.details)).toMatchObject({
+      provider: 'google',
+      accountCount: 1,
+      revocationOutcomes: ['revoked'],
+      localCredentialsRemoved: true,
+      localSourcesRemoved: true,
+    });
+    expect(audit.details).not.toContain('refresh-u');
+
+    await app.makeCaller(U).gmailEnhanced.disconnect();
+    const revocationAudits = await app.db.select().from(app.schema.auditLogs)
+      .where(and(
+        eq(app.schema.auditLogs.userId, U.id),
+        eq(app.schema.auditLogs.action, 'provider.disconnect_revoked'),
+      ));
+    expect(revocationAudits).toHaveLength(1);
   });
 
   it('rejects new Outlook OAuth connections while its collector is unavailable', async () => {
@@ -117,6 +141,18 @@ suite('Phases 061–070', () => {
       .where(and(eq(app.schema.evidenceSources.userId, U.id), eq(app.schema.evidenceSources.sourceType, 'Gmail')));
     expect(accounts).toHaveLength(1);
     expect(sources).toHaveLength(1);
+
+    const [audit] = await app.db.select().from(app.schema.auditLogs)
+      .where(and(
+        eq(app.schema.auditLogs.userId, U.id),
+        eq(app.schema.auditLogs.action, 'provider.disconnect_failed'),
+      ));
+    expect(JSON.parse(audit.details)).toMatchObject({
+      provider: 'google',
+      reason: 'upstream_revocation_failed',
+      localStateRetained: true,
+    });
+    expect(audit.details).not.toContain('refresh-retry');
   });
 
   it('removes a Google connection when the upstream token is already invalid', async () => {
@@ -131,6 +167,70 @@ suite('Phases 061–070', () => {
     const account = await app.db.select().from(app.schema.emailAccounts)
       .where(eq(app.schema.emailAccounts.id, 'GOOGLE_U61_INVALID'));
     expect(account).toHaveLength(0);
+
+    const [audit] = await app.db.select().from(app.schema.auditLogs)
+      .where(and(
+        eq(app.schema.auditLogs.userId, U.id),
+        eq(app.schema.auditLogs.entityId, 'GOOGLE_U61_INVALID'),
+      ));
+    expect(JSON.parse(audit.details).revocationOutcome).toBe('already_invalid');
+  });
+
+  it('records a Google connection without tokens or account PII in audit details', async () => {
+    const accountId = await saveEmailAccount(
+      U.id,
+      'gmail',
+      {
+        accessToken: 'connection-access-secret',
+        refreshToken: 'connection-refresh-secret',
+        expiresIn: 3600,
+        tokenType: 'Bearer',
+        scope: 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/drive.readonly',
+      },
+      { email: 'private-google-account@example.com', displayName: 'Private Owner' },
+    );
+
+    const [audit] = await app.db.select().from(app.schema.auditLogs)
+      .where(and(
+        eq(app.schema.auditLogs.userId, U.id),
+        eq(app.schema.auditLogs.entityId, accountId),
+      ));
+    const details = JSON.parse(audit.details);
+    expect(audit.action).toBe('provider.connected');
+    expect(details).toMatchObject({ provider: 'google', refreshGrantStored: true });
+    expect(details.requestedScopes).toContain('https://www.googleapis.com/auth/gmail.readonly');
+    expect(details.tokenReportedScopes).toContain('https://www.googleapis.com/auth/drive.readonly');
+    expect(audit.details).not.toContain('connection-access-secret');
+    expect(audit.details).not.toContain('connection-refresh-secret');
+    expect(audit.details).not.toContain('private-google-account@example.com');
+    expect(audit.details).not.toContain('Private Owner');
+  });
+
+  it('records a timeline source open only for owner-accessible evidence without storing its URL', async () => {
+    const caseId = 'CASE_SOURCE_AUDIT_61';
+    const evidenceId = 'EVIDENCE_SOURCE_AUDIT_61';
+    await app.db.insert(app.schema.cases).values(buildCase({ id: caseId, userId: U.id }));
+    await app.db.insert(app.schema.evidence).values(buildEvidence({
+      id: evidenceId,
+      caseId,
+      userId: U.id,
+      fileUrl: 'https://private.example.test/legal-document?id=secret',
+    }));
+
+    await expect(app.makeCaller(ADMIN).evidenceFiles.recordSourceOpened({ id: evidenceId }))
+      .rejects.toThrow('File not found');
+    await app.makeCaller(U).evidenceFiles.recordSourceOpened({ id: evidenceId });
+
+    const rows = await app.db.select().from(app.schema.auditLogs)
+      .where(eq(app.schema.auditLogs.action, 'evidence.source_opened'));
+    const audit = rows.find((row: any) => row.entityId === evidenceId);
+    expect(audit?.userId).toBe(U.id);
+    expect(JSON.parse(audit.details)).toEqual({
+      caseId,
+      accessMethod: 'source_url',
+      dispatchConfirmed: true,
+    });
+    expect(audit.details).not.toContain('private.example.test');
   });
 
   it('Phase 062 — pre-send review returns safety facts and never sends', async () => {


### PR DESCRIPTION
## What changed
- record owner-scoped Google connection, disconnect, and disconnect-failure audit events without tokens or account PII
- distinguish confirmed revocation, already-invalid grants, and no-op disconnects so release evidence cannot be falsely satisfied
- record timeline source opens only after the renderer dispatches the document and the server revalidates ownership
- document the audit evidence used during Google release acceptance

## Why
The release checklist required durable evidence for Google consent/disconnect and timeline source access, but those actions previously depended on screenshots or operator memory. Disconnect entry points also discarded Google's terminal outcome category.

## Validation
- `npm run gate` (53 files, 344 tests)
- `npm run build`
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)
- `npm run test:a11y:browser` (2 passed)
- `npm run dist:win`
- `npm run verify:electron-native` (Electron 43.1.0, ABI 148)
- `scripts/verify-single-instance.ps1` (startup, second launch, restart, secret preservation passed)
- unsigned artifact SHA-256: `d5914a9b5f77664fb3b322dcc181ca7f18a61e2922d051de464718f3bae340a3`

## External gates
Brand approval and a live Google acceptance run remain owner-controlled and are not claimed by this PR.