### PR TITLE
Port focused Paper Trail timeline analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ versioning; dates are ISO. Version is sourced from `package.json` and surfaced b
   credential and refreshing status immediately.
 
 ### Added
+- Extended the source-linked document reconstruction with participant and legal-
+  topic focus, plus the dated actions retained for each selected station. This
+  ports the useful focused-analysis concepts from the predecessor's unrelated
+  `feat/document-timeline-generator` history without importing its prototype
+  Flask runtime, global cache, or unaudited directory watcher.
 - Added a source-linked metro-style case reconstruction that displays every
   evidence document as a dated station, separates provider/reference-backed
   links from confidence-labelled inferred relationships, supports route and

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The Electron main process starts the Express/tRPC server and React renderer toge
 - Trace a selected document backward and forward, filter routes, switch between
   horizontal and vertical maps, zoom, and use an accessible chronological list;
   each station retains a direct source-document control.
+- Focus the reconstruction on one source-derived participant or legal topic and
+  inspect every dated action retained for the selected document.
 - Browse source-linked legal events horizontally or vertically, source documents,
   and operational case activity from one Timeline workspace.
 - Generate source-linked case summaries, lawyer briefings, red-line drafts, and approval-bound case bundles.

--- a/docs/ACCEPTANCE_TESTS.md
+++ b/docs/ACCEPTANCE_TESTS.md
@@ -26,6 +26,7 @@ temporary SQLite databases; they do not contact external people or accounts.
 | AC19 | Recover the Flask legal ledger, auth sessions, OAuth vault, and referenced uploads while preserving every previous path | `test_flask_recovery.py` and blocking Flask recovery drill | Automated |
 | AC20 | Migrate exactly one Flask owner into Electron without cross-owner records, provenance loss, secret transfer, duplicate imports, or live-send activation | `test_flask_to_desktop_migration.py` and `tests/backend/legacyImports.test.ts` | Automated |
 | AC21 | Reconstruct every owned case document as a source-linked station while distinguishing explicit links from confidence-labelled suggestions | `tests/backend/caseReconstruction.test.ts`, document-intelligence and production-readiness suites | Automated |
+| AC22 | Focus a reconstruction by source-derived participant or legal topic and retain the selected document's dated actions | `tests/backend/caseReconstruction.test.ts`, renderer accessibility suite | Automated |
 
 ## Target-Environment Acceptance
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,10 @@ Important boundaries:
   confidence. The graph does not persist a second evidence authority.
 - The React renderer owns deterministic SVG route layout and transient view
   state only. It provides horizontal/vertical maps plus a chronological list,
-  while all station and source identities come from the server response.
+  while all station and source identities come from the server response. Its
+  focus facets use source-derived analyzed parties and legal issues, and each
+  station carries the dated source-linked actions already retained for that
+  document; no separate NLP index or evidence authority is introduced.
 - Desktop Outreach consolidates analytics, the official NOvA lawyer directory,
   and owner-scoped media/organization directories. Public discovery is bounded,
   sends legal-area terms rather than case prose, and persists candidates behind

--- a/docs/PAPER_TRAIL_TIMELINE_GENERATOR_AUDIT.md
+++ b/docs/PAPER_TRAIL_TIMELINE_GENERATOR_AUDIT.md
@@ -1,0 +1,42 @@
+# Paper Trail Timeline Generator Audit
+
+Date: 2026-07-22
+
+Source: `Noodzakelijk-Online/024-Paper-trail-visualizer`, branch
+`feat/document-timeline-generator`, commit `2508587`.
+
+The branch has no common Git ancestor with the predecessor repository's main
+branch. It is a separate Python/Flask prototype, not an incremental change to
+the React metro-map implementation.
+
+## Ported concepts
+
+| Prototype concept | LARO implementation |
+| --- | --- |
+| Filter a timeline around one subject | Focus the case reconstruction on a source-derived analyzed participant |
+| Group documents by discovered topics | Focus on named, source-linked legal issues instead of opaque LDA topic numbers |
+| Extract actions associated with dates | Show the dated, source-linked actions retained for the selected document |
+| Explore entity relationships | Combine participant focus with explicit and confidence-labelled document relationships |
+| Refresh analysis when evidence changes | Use LARO's persisted imports, analysis state, automatic query invalidation, and controlled refresh |
+
+## Not ported
+
+- The Flask application uses a hard-coded session secret, process-global mutable
+  status, unauthenticated routes, and raw local paths.
+- The JSON cache is keyed by path and modification time and has no owner, case,
+  content-hash, migration, or concurrency boundary.
+- The English-only spaCy model and subject-verb-object heuristic are unsuitable
+  for LARO's Dutch/English legal evidence and do not retain source citations.
+- LDA labels such as `Topic #2` are not legal findings and provide no reviewable
+  source basis.
+- The filesystem watcher accepts a configured recursive path and analyzes files
+  from a web-server thread. LARO instead confines local-folder collection to
+  approved roots and managed evidence storage.
+- Generated PyVis/Jinja HTML is a second unaudited presentation runtime and does
+  not enforce LARO's owner-scoped source-opening contract.
+
+## Retirement conclusion
+
+LARO does not import, execute, or depend on this branch. Its useful interaction
+ideas are represented by the production reconstruction contract and renderer;
+the prototype branch is not required for operation or future migrations.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -27,8 +27,10 @@ lawyers, and prepares outreach. **You approve everything before anything is sent
    metadata or literal references, and dashed arrows are similarity suggestions.
    Select a station to read its summary and relationship basis, use the question
    mark control to open the source, and enable Trace selection to follow the
-   connected history. Legal events, source chronology, and operational activity
-   remain available in the adjacent tabs.
+   connected history. Use Focus to isolate documents involving one analyzed
+   participant or legal topic; selecting a station also reveals the dated actions
+   retained from that document. Legal events, source chronology, and operational
+   activity remain available in the adjacent tabs.
 5. **Review matched lawyers**: open the case to see ranked matches (expertise,
    availability, response time, distance). No one is contacted here.
 6. **Prepare & approve outreach**: prepare drafts, then review each. Before

--- a/server/caseReconstruction.ts
+++ b/server/caseReconstruction.ts
@@ -48,6 +48,14 @@ export type ReconstructionNode = {
   eventCount: number;
   analysisStatus: "complete" | "missing";
   confidence: number | null;
+  participants: string[];
+  topics: string[];
+  actions: Array<{
+    date: string;
+    title: string;
+    description: string;
+    actor: string | null;
+  }>;
 };
 
 export type ReconstructionEdge = {
@@ -61,7 +69,7 @@ export type ReconstructionEdge = {
 };
 
 export type CaseReconstruction = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   nodes: ReconstructionNode[];
   edges: ReconstructionEdge[];
   routes: Array<{
@@ -348,6 +356,12 @@ export function buildCaseReconstruction(options: {
     const documentEvents = (eventsByDocument.get(document.evidenceId) ?? [])
       .sort((left, right) => left.date.localeCompare(right.date));
     const analysis = document.analysis;
+    const participants = [...new Set([
+      ...documentEvents.map((event) => event.actor).filter((actor): actor is string => Boolean(actor?.trim())),
+      ...(analysis?.parties.map((party) => party.text).filter(Boolean) ?? []),
+    ])].sort((left, right) => left.localeCompare(right));
+    const topics = [...new Set(analysis?.legalIssues.map((issue) => issue.text).filter(Boolean) ?? [])]
+      .sort((left, right) => left.localeCompare(right));
     return {
       id: document.evidenceId,
       title: document.title,
@@ -360,6 +374,14 @@ export function buildCaseReconstruction(options: {
       eventCount: documentEvents.length,
       analysisStatus: analysis ? "complete" : "missing",
       confidence: analysis?.confidence ?? null,
+      participants,
+      topics,
+      actions: documentEvents.map((event) => ({
+        date: event.date,
+        title: event.title,
+        description: event.description,
+        actor: event.actor,
+      })),
     };
   }).sort((left, right) => left.date.localeCompare(right.date) || left.title.localeCompare(right.title) || left.id.localeCompare(right.id));
 
@@ -390,5 +412,5 @@ export function buildCaseReconstruction(options: {
       : null,
   ].filter((item): item is string => Boolean(item));
 
-  return { schemaVersion: 1, nodes, edges, routes, warnings };
+  return { schemaVersion: 2, nodes, edges, routes, warnings };
 }

--- a/server/help.ts
+++ b/server/help.ts
@@ -20,7 +20,7 @@ export const HELP_TOPICS: HelpTopic[] = [
   { id: "evidence", title: "Add evidence", step: 2,
     body: "Attach documents or connect Gmail/Drive (if configured) to collect supporting materials. Each item keeps its source and a content hash for provenance." },
   { id: "document-map", title: "Reconstruct the document history", step: 3,
-    body: "Open a case and choose Timeline, then Document map. Documents are dated stations and event categories are colored routes. Solid links come from source metadata or literal references. Dashed links are review-only similarity suggestions with confidence and supporting reasons. Select a station to trace its chain or open the source document." },
+    body: "Open a case and choose Timeline, then Document map. Documents are dated stations and event categories are colored routes. Solid links come from source metadata or literal references. Dashed links are review-only similarity suggestions with confidence and supporting reasons. Focus the map on an analyzed participant or legal topic, then select a station to review its dated actions, trace its chain, or open the source document." },
   { id: "matching", title: "Review matched lawyers", step: 4,
     body: "Open a case to see ranked lawyer matches based on expertise, availability, response time and distance. No lawyer is contacted at this stage." },
   { id: "approval", title: "Prepare and approve outreach", step: 5,

--- a/src/renderer/components/CaseReconstruction.tsx
+++ b/src/renderer/components/CaseReconstruction.tsx
@@ -38,6 +38,9 @@ type ReconstructionNode = {
   eventCount: number;
   analysisStatus: "complete" | "missing";
   confidence: number | null;
+  participants: string[];
+  topics: string[];
+  actions: Array<{ date: string; title: string; description: string; actor: string | null }>;
 };
 
 type ReconstructionEdge = {
@@ -51,7 +54,7 @@ type ReconstructionEdge = {
 };
 
 type Reconstruction = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   nodes: ReconstructionNode[];
   edges: ReconstructionEdge[];
   routes: Array<{ id: RouteId; label: string; documentCount: number; eventCount: number }>;
@@ -114,6 +117,7 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
   const [showInferred, setShowInferred] = useState(true);
   const [minimumConfidence, setMinimumConfidence] = useState(52);
   const [routeFilter, setRouteFilter] = useState<RouteId | "all">("all");
+  const [focusFilter, setFocusFilter] = useState("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [traceSelected, setTraceSelected] = useState(false);
   const [zoom, setZoom] = useState(1);
@@ -154,8 +158,32 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
     }
   };
 
-  const visibleNodes = useMemo(() => reconstruction?.nodes.filter((node) =>
-    routeFilter === "all" || node.route === routeFilter) ?? [], [reconstruction, routeFilter]);
+  const focusOptions = useMemo(() => {
+    if (!reconstruction) return [];
+    const counts = new Map<string, { label: string; group: "Participant" | "Topic"; count: number }>();
+    for (const node of reconstruction.nodes) {
+      for (const participant of node.participants) {
+        const id = `participant:${participant}`;
+        const current = counts.get(id);
+        counts.set(id, { label: participant, group: "Participant", count: (current?.count ?? 0) + 1 });
+      }
+      for (const topic of node.topics) {
+        const id = `topic:${topic}`;
+        const current = counts.get(id);
+        counts.set(id, { label: topic, group: "Topic", count: (current?.count ?? 0) + 1 });
+      }
+    }
+    return [...counts.entries()]
+      .map(([id, option]) => ({ id, ...option }))
+      .sort((left, right) => left.group.localeCompare(right.group) || right.count - left.count || left.label.localeCompare(right.label));
+  }, [reconstruction]);
+  const visibleNodes = useMemo(() => reconstruction?.nodes.filter((node) => {
+    if (routeFilter !== "all" && node.route !== routeFilter) return false;
+    if (focusFilter === "all") return true;
+    const [kind, ...parts] = focusFilter.split(":");
+    const value = parts.join(":");
+    return kind === "participant" ? node.participants.includes(value) : node.topics.includes(value);
+  }) ?? [], [reconstruction, routeFilter, focusFilter]);
   const visibleNodeIds = useMemo(() => new Set(visibleNodes.map((node) => node.id)), [visibleNodes]);
   const visibleEdges = useMemo(() => reconstruction?.edges.filter((edge) =>
     visibleNodeIds.has(edge.from) && visibleNodeIds.has(edge.to) &&
@@ -165,6 +193,10 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
     [traceSelected, selectedId, visibleEdges]);
   const selectedNode = reconstruction?.nodes.find((node) => node.id === selectedId) ?? null;
   const selectedEdges = visibleEdges.filter((edge) => edge.from === selectedId || edge.to === selectedId);
+
+  useEffect(() => {
+    if (selectedId && !visibleNodeIds.has(selectedId)) setSelectedId(visibleNodes[0]?.id ?? null);
+  }, [selectedId, visibleNodeIds, visibleNodes]);
 
   if (!reconstruction && generateMutation.isPending) {
     return (
@@ -234,6 +266,22 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
             {reconstruction.routes.map((route) => <option key={route.id} value={route.id}>{route.label} ({route.documentCount})</option>)}
           </select>
         </label>
+        <label className="min-w-52 text-xs text-muted-foreground">
+          Focus
+          <select className="mt-1 h-9 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground" value={focusFilter} onChange={(event) => setFocusFilter(event.target.value)}>
+            <option value="all">All participants and topics</option>
+            {focusOptions.filter((option) => option.group === "Participant").length ? (
+              <optgroup label="Participants">
+                {focusOptions.filter((option) => option.group === "Participant").map((option) => <option key={option.id} value={option.id}>{option.label} ({option.count})</option>)}
+              </optgroup>
+            ) : null}
+            {focusOptions.filter((option) => option.group === "Topic").length ? (
+              <optgroup label="Legal topics">
+                {focusOptions.filter((option) => option.group === "Topic").map((option) => <option key={option.id} value={option.id}>{option.label} ({option.count})</option>)}
+              </optgroup>
+            ) : null}
+          </select>
+        </label>
         <label className="min-w-44 text-xs text-muted-foreground">
           Minimum link confidence: {minimumConfidence}%
           <input className="mt-2 block w-full accent-orange-500" type="range" min="50" max="95" step="1" value={minimumConfidence} onChange={(event) => setMinimumConfidence(Number(event.target.value))} />
@@ -259,7 +307,13 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
         <span className="flex items-center gap-2"><span className="w-6 border-t-2 border-dashed border-slate-500" /> Suggested relationship</span>
       </div>
 
-      {view === "map" ? (
+      {!visibleNodes.length ? (
+        <div className="border border-dashed border-border p-8 text-center">
+          <Focus className="mx-auto h-8 w-8 text-muted-foreground" />
+          <h3 className="mt-3 font-medium">No documents match this focus</h3>
+          <Button type="button" variant="outline" size="sm" className="mt-3" onClick={() => { setRouteFilter("all"); setFocusFilter("all"); }}>Clear filters</Button>
+        </div>
+      ) : view === "map" ? (
         <ReconstructionMap
           nodes={visibleNodes}
           edges={visibleEdges}
@@ -301,6 +355,12 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
                 <span>{selectedNode.eventCount} dated event{selectedNode.eventCount === 1 ? "" : "s"}</span>
                 {selectedNode.confidence !== null ? <span>Analysis confidence: {selectedNode.confidence}%</span> : null}
               </div>
+              {selectedNode.participants.length || selectedNode.topics.length ? (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {selectedNode.participants.map((participant) => <Badge key={`participant:${participant}`} variant="secondary">{participant}</Badge>)}
+                  {selectedNode.topics.map((topic) => <Badge key={`topic:${topic}`} variant="outline">{topic}</Badge>)}
+                </div>
+              ) : null}
             </div>
             <Button type="button" variant="outline" size="sm" title="Open source document" onClick={() => void openSource(selectedNode.id)}><CircleHelp className="mr-2 h-4 w-4" /> Source</Button>
           </div>
@@ -319,6 +379,20 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
               })}
             </div>
           ) : <p className="mt-3 text-sm text-muted-foreground">No relationship survives the current filters for this document.</p>}
+          {selectedNode.actions.length ? (
+            <div className="mt-4 border-t border-border/60 pt-4">
+              <h4 className="text-sm font-medium">Dated actions in this document</h4>
+              <div className="mt-2 grid gap-2 lg:grid-cols-2">
+                {selectedNode.actions.map((action, index) => (
+                  <div key={`${action.date}:${action.title}:${index}`} className="border-l-2 border-border pl-3 text-sm">
+                    <div className="flex flex-wrap items-center gap-2"><span className="font-medium">{action.title}</span><Badge variant="outline">{formatDate(action.date)}</Badge></div>
+                    <p className="mt-1 leading-5 text-muted-foreground">{action.description}</p>
+                    {action.actor ? <p className="mt-1 text-xs text-muted-foreground">Actor: {action.actor}</p> : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
         </section>
       ) : null}
 

--- a/src/renderer/components/EnhancedCaseDetailsDialog.tsx
+++ b/src/renderer/components/EnhancedCaseDetailsDialog.tsx
@@ -661,12 +661,12 @@ export default function EnhancedCaseDetailsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="sm:max-w-[92vw] max-w-[1400px] h-[88vh] p-0 overflow-hidden bg-background border-border/40 shadow-2xl shadow-black/40"
+        className="h-[94vh] w-[calc(100vw-1rem)] max-w-[1400px] overflow-hidden border-border/40 bg-background p-0 shadow-2xl shadow-black/40 sm:h-[88vh] sm:max-w-[92vw]"
       >
         {/* ─── top header bar ─── */}
-        <div className="flex items-center justify-between border-b border-border/40 px-6 py-4 bg-gradient-to-r from-background via-card to-background">
-          <div className="flex items-center gap-4 min-w-0">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-orange-500/15 ring-1 ring-orange-500/30">
+        <div className="flex items-center justify-between border-b border-border/40 bg-gradient-to-r from-background via-card to-background px-3 py-3 sm:px-6 sm:py-4">
+          <div className="flex min-w-0 items-center gap-2 sm:gap-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-orange-500/15 ring-1 ring-orange-500/30 sm:h-10 sm:w-10 sm:rounded-xl">
               <Briefcase className="h-5 w-5 text-orange-500" />
             </div>
             <div className="min-w-0">
@@ -680,7 +680,7 @@ export default function EnhancedCaseDetailsDialog({
               </DialogHeader>
             </div>
             {caseData && (
-              <div className="flex items-center gap-2 ml-2">
+              <div className="ml-2 hidden items-center gap-2 lg:flex">
                 <Badge variant="outline" className={`text-[11px] ${statusClass(caseData.status)}`}>
                   {caseData.status}
                 </Badge>
@@ -691,30 +691,30 @@ export default function EnhancedCaseDetailsDialog({
             )}
           </div>
 
-          <div className="flex items-center gap-1.5 shrink-0">
-            <Button onClick={() => exportCaseSummary(caseData)} variant="ghost" size="sm" className="h-8 px-2.5 text-xs text-muted-foreground hover:text-foreground">
-              <Download className="w-3.5 h-3.5 mr-1.5" /> Export
+          <div className="flex shrink-0 items-center gap-1 sm:gap-1.5">
+            <Button onClick={() => exportCaseSummary(caseData)} variant="ghost" size="sm" title="Export case" aria-label="Export case" className="h-8 w-8 px-0 text-xs text-muted-foreground hover:text-foreground sm:w-auto sm:px-2.5">
+              <Download className="h-3.5 w-3.5 sm:mr-1.5" /> <span className="hidden sm:inline">Export</span>
             </Button>
-            <Button onClick={() => printCaseSummary(caseData)} variant="ghost" size="sm" className="h-8 px-2.5 text-xs text-muted-foreground hover:text-foreground">
-              <Printer className="w-3.5 h-3.5 mr-1.5" /> Print
+            <Button onClick={() => printCaseSummary(caseData)} variant="ghost" size="sm" title="Print case" aria-label="Print case" className="h-8 w-8 px-0 text-xs text-muted-foreground hover:text-foreground sm:w-auto sm:px-2.5">
+              <Printer className="h-3.5 w-3.5 sm:mr-1.5" /> <span className="hidden sm:inline">Print</span>
             </Button>
             {!isEditing && (
-              <Button onClick={handleEdit} variant="ghost" size="sm" className="h-8 px-2.5 text-xs text-orange-400 hover:text-orange-300 hover:bg-orange-500/10">
-                <Edit className="w-3.5 h-3.5 mr-1.5" /> Edit
+              <Button onClick={handleEdit} variant="ghost" size="sm" title="Edit case" aria-label="Edit case" className="h-8 w-8 px-0 text-xs text-orange-400 hover:bg-orange-500/10 hover:text-orange-300 sm:w-auto sm:px-2.5">
+                <Edit className="h-3.5 w-3.5 sm:mr-1.5" /> <span className="hidden sm:inline">Edit</span>
               </Button>
             )}
-            <div className="w-px h-5 bg-border/60 mx-1" />
-            <Button onClick={() => onOpenChange(false)} variant="ghost" size="sm" className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground">
+            <div className="mx-0.5 h-5 w-px bg-border/60 sm:mx-1" />
+            <Button onClick={() => onOpenChange(false)} variant="ghost" size="sm" aria-label="Close case details" className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground">
               <X className="w-4 h-4" />
             </Button>
           </div>
         </div>
 
         {/* ─── body: sidebar + content ─── */}
-        <div className="flex flex-1 min-h-0">
+        <div className="flex min-h-0 flex-1 flex-col md:flex-row">
           {/* sidebar nav */}
-          <nav className="w-[200px] shrink-0 border-r border-border/40 bg-card/30 py-3 overflow-y-auto">
-            <div className="space-y-0.5 px-2">
+          <nav className="w-full shrink-0 overflow-x-auto border-b border-border/40 bg-card/30 py-2 md:w-[200px] md:overflow-y-auto md:border-b-0 md:border-r md:py-3">
+            <div className="flex gap-1 px-2 md:block md:space-y-0.5">
               {NAV_ITEMS.map((item) => {
                 const Icon = item.icon;
                 const active = activeTab === item.id;
@@ -723,7 +723,7 @@ export default function EnhancedCaseDetailsDialog({
                     key={item.id}
                     onClick={() => handleTabChange(item.id)}
                     className={`
-                      group w-full flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13px] font-medium transition-all duration-150
+                      group flex w-auto shrink-0 items-center gap-2 rounded-lg px-3 py-2 text-[13px] font-medium transition-all duration-150 md:w-full md:gap-2.5
                       ${active
                         ? "bg-orange-500/12 text-orange-400 ring-1 ring-orange-500/20"
                         : "text-muted-foreground hover:text-foreground hover:bg-card/60"
@@ -732,7 +732,7 @@ export default function EnhancedCaseDetailsDialog({
                   >
                     <Icon className={`w-4 h-4 shrink-0 transition-colors ${active ? "text-orange-500" : "text-muted-foreground/60 group-hover:text-muted-foreground"}`} />
                     <span className="truncate">{item.label}</span>
-                    {active && <ChevronRight className="w-3 h-3 ml-auto text-orange-500/60" />}
+                    {active && <ChevronRight className="ml-auto hidden h-3 w-3 text-orange-500/60 md:block" />}
                   </button>
                 );
               })}
@@ -740,7 +740,7 @@ export default function EnhancedCaseDetailsDialog({
           </nav>
 
           {/* main content area */}
-          <main className="flex-1 min-w-0 overflow-y-auto p-6">
+          <main className="min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">
             {caseLoading ? (
               <div className="space-y-4">
                 <Skeleton className="h-8 w-48 rounded-lg" />
@@ -993,7 +993,7 @@ export default function EnhancedCaseDetailsDialog({
                       <GitBranch className="w-5 h-5 text-orange-500" /> Evidence Timeline
                     </h2>
                       <Tabs defaultValue="reconstruction" className="w-full">
-                      <TabsList className="h-auto w-full justify-start gap-1 border border-border/30 bg-card/40 p-1">
+                      <TabsList className="h-auto w-full justify-start gap-1 overflow-x-auto border border-border/30 bg-card/40 p-1">
                         <TabsTrigger value="reconstruction" className="text-xs">Document map</TabsTrigger>
                         <TabsTrigger value="events" className="text-xs">Legal events</TabsTrigger>
                         <TabsTrigger value="sources" className="text-xs">Source documents</TabsTrigger>

--- a/tests/backend/caseReconstruction.test.ts
+++ b/tests/backend/caseReconstruction.test.ts
@@ -77,12 +77,21 @@ describe("case document reconstruction", () => {
       ],
     });
 
-    expect(result.schemaVersion).toBe(1);
+    expect(result.schemaVersion).toBe(2);
     expect(result.nodes.map((node) => node.id)).toEqual(["decision", "objection", "attachment", "unanalyzed"]);
     expect(result.nodes.find((node) => node.id === "unanalyzed")).toMatchObject({
       date: "2026-07-22",
       analysisStatus: "missing",
       summary: "Imported image",
+    });
+    expect(result.nodes.find((node) => node.id === "decision")).toMatchObject({
+      participants: expect.arrayContaining(["Gemeente Utrecht"]),
+      topics: expect.arrayContaining(["administrative law"]),
+      actions: [expect.objectContaining({
+        date: "2026-07-14",
+        title: "Besluit",
+        actor: "Gemeente Utrecht",
+      })],
     });
     expect(result.edges).toEqual(expect.arrayContaining([
       expect.objectContaining({ from: "decision", to: "attachment", relationship: "attachment_of", evidence: "explicit", confidence: 1 }),

--- a/tests/browser/rendererAccessibility.spec.ts
+++ b/tests/browser/rendererAccessibility.spec.ts
@@ -52,6 +52,42 @@ function formatViolations(
     .join("\n");
 }
 
+function analysisResult(options: { party: string; date: string; title: string; text: string }) {
+  return {
+    schemaVersion: 2,
+    analysisVersion: "2.2.0",
+    contentHash: options.title.toLowerCase().replace(/\s+/g, "-").padEnd(64, "0").slice(0, 64),
+    status: "complete",
+    extractionMethod: "plain_text",
+    extractionConfidence: null,
+    providerStatus: "not_requested",
+    providerMessage: null,
+    documentType: "administrative decision",
+    confidence: 88,
+    summary: options.text,
+    analyzedChars: options.text.length,
+    analyzedWords: options.text.split(/\s+/).length,
+    truncated: false,
+    citations: [{ id: "src-1", quote: options.text, start: 0, end: options.text.length, lineStart: 1, lineEnd: 1 }],
+    parties: [{ text: options.party, citations: ["src-1"] }],
+    dates: [{ text: options.date, normalized: options.date, citations: ["src-1"] }],
+    amounts: [],
+    claims: [],
+    obligations: [],
+    legalIssues: [{ text: "administrative law", citations: ["src-1"] }],
+    riskFlags: [],
+    timelineEvents: [{
+      date: options.date,
+      title: options.title,
+      text: options.text,
+      actor: options.party,
+      importance: "high",
+      category: "legal",
+      citations: ["src-1"],
+    }],
+  };
+}
+
 test("all supported routes pass the blocking renderer accessibility audit", async ({ page }) => {
   const consoleErrors: string[] = [];
   const pageErrors: string[] = [];
@@ -144,4 +180,73 @@ test("Settings presents an owned Flask migration without responsive overflow", a
       .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1))
       .toBe(true);
   }
+});
+
+test("document reconstruction focuses source-linked participants, topics, and actions", async ({ page }) => {
+  const email = await createAccount(page);
+  const database = new Database(resolve(".laro-a11y.sqlite"));
+  const now = Math.floor(Date.now() / 1_000);
+  const caseId = `A11Y_RECONSTRUCTION_${now}`;
+  try {
+    const user = database.prepare("SELECT id FROM users WHERE email = ?").get(email) as { id: string } | undefined;
+    expect(user?.id).toBeTruthy();
+    database.prepare(
+      `INSERT INTO cases (id, userId, clientName, caseType, caseSummary, urgency, status, legalAreas, createdAt, updatedAt)
+       VALUES (?, ?, 'Focused reconstruction', 'Administrative dispute', 'Source-linked timeline QA', 'High', 'active', '["administrative law"]', ?, ?)`,
+    ).run(caseId, user!.id, now, now);
+
+    const documents = [
+      {
+        id: `${caseId}_DECISION`, title: "Municipal decision.txt", party: "Gemeente Utrecht",
+        date: "2026-07-14", action: "Municipal decision issued",
+        text: "Gemeente Utrecht issued the administrative decision on 2026-07-14.",
+      },
+      {
+        id: `${caseId}_OBJECTION`, title: "Objection.txt", party: "Jan de Vries",
+        date: "2026-07-20", action: "Objection submitted",
+        text: "Jan de Vries submitted an objection under administrative law on 2026-07-20.",
+      },
+    ];
+    const insertEvidence = database.prepare(
+      `INSERT INTO evidence (id, caseId, userId, type, source, title, description, mimeType, metadata, relevant, createdAt, updatedAt)
+       VALUES (?, ?, ?, 'document', 'manual', ?, ?, 'text/plain', '{}', 1, ?, ?)`,
+    );
+    const insertAnalysis = database.prepare(
+      `INSERT INTO document_analyses
+       (id, evidenceId, caseId, userId, analysisVersion, contentHash, status, extractionMethod, providerStatus,
+        documentType, confidence, summary, result, analyzedChars, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, '2.2.0', ?, 'complete', 'plain_text', 'not_requested',
+        'administrative decision', 88, ?, ?, ?, ?, ?)`,
+    );
+    for (const [index, document] of documents.entries()) {
+      const createdAt = now + index;
+      const result = analysisResult({ party: document.party, date: document.date, title: document.action, text: document.text });
+      insertEvidence.run(document.id, caseId, user!.id, document.title, document.text, createdAt, createdAt);
+      insertAnalysis.run(
+        `${document.id}_ANALYSIS`, document.id, caseId, user!.id, result.contentHash,
+        result.summary, JSON.stringify(result), result.analyzedChars, createdAt, createdAt,
+      );
+    }
+  } finally {
+    database.close();
+  }
+
+  await page.goto("/cases", { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: "View Your Case Details" }).click();
+  await page.getByRole("button", { name: "Timeline", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Evidence Timeline" })).toBeVisible();
+  const focus = page.getByLabel("Focus");
+  await expect(focus).toContainText("Gemeente Utrecht (1)");
+  await expect(focus).toContainText("administrative law (2)");
+  await focus.selectOption({ label: "Jan de Vries (1)" });
+  await expect(page.getByText("Objection.txt", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Municipal decision.txt", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("Dated actions in this document")).toBeVisible();
+  await expect(page.getByText("Objection submitted", { exact: true })).toBeVisible();
+
+  for (const viewport of VIEWPORTS) {
+    await page.setViewportSize(viewport);
+    await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
+  }
+  await page.screenshot({ path: "test-results/case-reconstruction-focus.png", fullPage: false });
 });

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -106,6 +106,8 @@ describe('production readiness regressions', () => {
     expect(reconstructionUi).toContain('Suggested links');
     expect(reconstructionUi).toContain('Open source document');
     expect(reconstructionUi).toContain('Trace selection');
+    expect(reconstructionUi).toContain('All participants and topics');
+    expect(reconstructionUi).toContain('Dated actions in this document');
     expect(analysisUi).toContain('Analyze all pending');
     expect(analysisUi).toContain('documentAnalysis.byCase.useQuery');
     expect(migration).toContain('CREATE TABLE `document_analyses`');


### PR DESCRIPTION
## What changed

- Adds participant and legal-topic focus to the source-linked document reconstruction.
- Carries every dated source-linked action into the selected station detail.
- Improves the case dialog's mobile layout with compact header actions and horizontal navigation.
- Adds a browser regression that seeds owned analyzed evidence and exercises focus, actions, and responsive layout.
- Documents the independent `feat/document-timeline-generator` branch audit and retirement decision.

## Why

The predecessor branch contains useful subject, topic, entity, and action concepts, but its unrelated Flask/NLP prototype lacks LARO's ownership, provenance, citation, storage, and runtime boundaries. This ports the useful behavior onto LARO's existing source-grounded reconstruction without importing the prototype runtime.

## Validation

- `npm run gate`: 56 files, 356 tests passed
- `python -m pytest -q`: 222 passed
- `npm run test:a11y:browser`: 3 passed
- `npm run readiness:production`: passed with isolated strong readiness secrets
- `npm run build`: passed
- `npm audit --audit-level=high`: 0 vulnerabilities
