### PR TITLE
Complete Paper Trail reconstruction port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ versioning; dates are ISO. Version is sourced from `package.json` and surfaced b
   credential and refreshing status immediately.
 
 ### Added
+- Completed the safe Paper Trail Visualizer port with neutral document-story
+  phases, source-backed key moments, and connected-chain summaries. The
+  predecessor's mock browser collectors and unsupported justice-probability
+  claims remain intentionally excluded.
 - Extended the source-linked document reconstruction with participant and legal-
   topic focus, plus the dated actions retained for each selected station. This
   ports the useful focused-analysis concepts from the predecessor's unrelated

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The Electron main process starts the Express/tRPC server and React renderer toge
   each station retains a direct source-document control.
 - Focus the reconstruction on one source-derived participant or legal topic and
   inspect every dated action retained for the selected document.
+- Read the evidence as neutral date-ordered story phases, jump to source-backed
+  key moments, and inspect connected chains with separate verified and inferred
+  link counts. These views never infer motive or a legal outcome.
 - Browse source-linked legal events horizontally or vertically, source documents,
   and operational case activity from one Timeline workspace.
 - Generate source-linked case summaries, lawyer briefings, red-line drafts, and approval-bound case bundles.

--- a/docs/PAPER_TRAIL_TIMELINE_GENERATOR_AUDIT.md
+++ b/docs/PAPER_TRAIL_TIMELINE_GENERATOR_AUDIT.md
@@ -2,8 +2,11 @@
 
 Date: 2026-07-22
 
-Source: `Noodzakelijk-Online/024-Paper-trail-visualizer`, branch
-`feat/document-timeline-generator`, commit `2508587`.
+Sources:
+
+- `Noodzakelijk-Online/024-Paper-trail-visualizer`, `main`, commit `d6e3237`.
+- `Noodzakelijk-Online/024-Paper-trail-visualizer`,
+  `feat/document-timeline-generator`, commit `2508587`.
 
 The branch has no common Git ancestor with the predecessor repository's main
 branch. It is a separate Python/Flask prototype, not an incremental change to
@@ -18,6 +21,11 @@ the React metro-map implementation.
 | Extract actions associated with dates | Show the dated, source-linked actions retained for the selected document |
 | Explore entity relationships | Combine participant focus with explicit and confidence-labelled document relationships |
 | Refresh analysis when evidence changes | Use LARO's persisted imports, analysis state, automatic query invalidation, and controlled refresh |
+| Divide a case into story phases | Present neutral, date-ordered phases whose summaries and counts resolve to source document IDs |
+| Identify key moments | Rank source documents using dated actions and verified links, without guessing intent or legal outcome |
+| Trace causal or influence chains | Expose connected document chains with explicit/inferred link counts and aggregate confidence |
+| Subway-style document history | Render dated document stations on legal, communication, financial, employment, and termination routes |
+| Inspect inputs and outputs | Inspect incoming and outgoing links, evidence basis, confidence, and the original source document |
 
 ## Not ported
 
@@ -34,9 +42,20 @@ the React metro-map implementation.
   approved roots and managed evidence storage.
 - Generated PyVis/Jinja HTML is a second unaudited presentation runtime and does
   not enforce LARO's owner-scoped source-opening contract.
+- The React prototype's browser connectors are placeholders that log actions or
+  return sample records. LARO retains its real, owner-scoped Google and local
+  evidence collectors instead.
+- Heuristic "justice score", "injustice probability", emotional-impact, and
+  cover-up labels are not ported. They present legal conclusions without a
+  reviewable evidentiary standard. LARO keeps facts, suggestions, confidence,
+  and source provenance separate.
+- Demo timelines, in-memory import/export state, and duplicate React/Vite UI
+  infrastructure are superseded by LARO's persisted case model and renderer.
 
 ## Retirement conclusion
 
-LARO does not import, execute, or depend on this branch. Its useful interaction
-ideas are represented by the production reconstruction contract and renderer;
-the prototype branch is not required for operation or future migrations.
+LARO does not import, execute, or depend on either predecessor branch. Every
+useful production-safe concept is represented by LARO's document intelligence,
+case reconstruction contract, and renderer. The predecessor repository is not
+required for operation or future migrations and can be retired after this
+LARO change is present on `main`.

--- a/server/caseReconstruction.ts
+++ b/server/caseReconstruction.ts
@@ -68,6 +68,37 @@ export type ReconstructionEdge = {
   basis: string[];
 };
 
+export type ReconstructionPhase = {
+  id: string;
+  label: string;
+  startDate: string;
+  endDate: string;
+  documentIds: string[];
+  documentCount: number;
+  eventCount: number;
+  summary: string;
+};
+
+export type ReconstructionChain = {
+  id: string;
+  documentIds: string[];
+  edgeIds: string[];
+  startDate: string;
+  endDate: string;
+  explicitLinkCount: number;
+  inferredLinkCount: number;
+  confidence: number;
+};
+
+export type ReconstructionKeyMoment = {
+  documentId: string;
+  date: string;
+  title: string;
+  reason: string;
+  verifiedLinkCount: number;
+  eventCount: number;
+};
+
 export type CaseReconstruction = {
   schemaVersion: 2;
   nodes: ReconstructionNode[];
@@ -78,6 +109,9 @@ export type CaseReconstruction = {
     documentCount: number;
     eventCount: number;
   }>;
+  phases: ReconstructionPhase[];
+  chains: ReconstructionChain[];
+  keyMoments: ReconstructionKeyMoment[];
   warnings: string[];
 };
 
@@ -341,6 +375,106 @@ function inferredEdges(
   return output;
 }
 
+function buildPhases(nodes: ReconstructionNode[]): ReconstructionPhase[] {
+  const dated = nodes.filter((node) => node.date !== "Undated");
+  if (!dated.length) return [];
+  const phaseCount = dated.length < 4 ? 1 : dated.length < 9 ? 2 : 3;
+  const labels = phaseCount === 1
+    ? ["Documented period"]
+    : phaseCount === 2
+      ? ["Opening record", "Later record"]
+      : ["Opening record", "Developing record", "Recent record"];
+
+  return labels.flatMap((label, index) => {
+    const start = Math.floor((index * dated.length) / phaseCount);
+    const end = Math.floor(((index + 1) * dated.length) / phaseCount);
+    const phaseNodes = dated.slice(start, end);
+    if (!phaseNodes.length) return [];
+    const eventCount = phaseNodes.reduce((sum, node) => sum + node.eventCount, 0);
+    const routeLabels = [...new Set(phaseNodes.map((node) => ROUTE_LABELS[node.route]))];
+    return [{
+      id: `phase-${index + 1}`,
+      label,
+      startDate: phaseNodes[0].date,
+      endDate: phaseNodes[phaseNodes.length - 1].date,
+      documentIds: phaseNodes.map((node) => node.id),
+      documentCount: phaseNodes.length,
+      eventCount,
+      summary: `${phaseNodes.length} source document${phaseNodes.length === 1 ? "" : "s"} across ${routeLabels.join(", ")}`
+        + `${eventCount ? `, containing ${eventCount} dated action${eventCount === 1 ? "" : "s"}` : ""}.`,
+    }];
+  });
+}
+
+function buildChains(nodes: ReconstructionNode[], edges: ReconstructionEdge[]): ReconstructionChain[] {
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+  const adjacency = new Map<string, Set<string>>();
+  for (const edge of edges) {
+    const left = adjacency.get(edge.from) ?? new Set<string>();
+    const right = adjacency.get(edge.to) ?? new Set<string>();
+    left.add(edge.to);
+    right.add(edge.from);
+    adjacency.set(edge.from, left);
+    adjacency.set(edge.to, right);
+  }
+  const visited = new Set<string>();
+  const chains: ReconstructionChain[] = [];
+  for (const node of nodes) {
+    if (visited.has(node.id) || !adjacency.has(node.id)) continue;
+    const pending = [node.id];
+    const documentIds: string[] = [];
+    while (pending.length) {
+      const current = pending.pop()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      documentIds.push(current);
+      for (const neighbor of adjacency.get(current) ?? []) {
+        if (!visited.has(neighbor)) pending.push(neighbor);
+      }
+    }
+    const documentSet = new Set(documentIds);
+    const chainEdges = edges.filter((edge) => documentSet.has(edge.from) && documentSet.has(edge.to));
+    const sortedDocuments = documentIds
+      .map((id) => nodeMap.get(id)!)
+      .sort((left, right) => left.date.localeCompare(right.date) || left.id.localeCompare(right.id));
+    chains.push({
+      id: `chain-${chains.length + 1}`,
+      documentIds: sortedDocuments.map((item) => item.id),
+      edgeIds: chainEdges.map((edge) => edge.id),
+      startDate: sortedDocuments.find((item) => item.date !== "Undated")?.date ?? "Undated",
+      endDate: [...sortedDocuments].reverse().find((item) => item.date !== "Undated")?.date ?? "Undated",
+      explicitLinkCount: chainEdges.filter((edge) => edge.evidence === "explicit").length,
+      inferredLinkCount: chainEdges.filter((edge) => edge.evidence === "inferred").length,
+      confidence: Number((chainEdges.reduce((sum, edge) => sum + edge.confidence, 0) / chainEdges.length).toFixed(2)),
+    });
+  }
+  return chains.sort((left, right) => right.documentIds.length - left.documentIds.length || left.id.localeCompare(right.id));
+}
+
+function buildKeyMoments(nodes: ReconstructionNode[], edges: ReconstructionEdge[]): ReconstructionKeyMoment[] {
+  return nodes
+    .map((node) => {
+      const verifiedLinkCount = edges.filter((edge) =>
+        edge.evidence === "explicit" && (edge.from === node.id || edge.to === node.id)).length;
+      const reasons = [
+        node.eventCount ? `${node.eventCount} source-linked dated action${node.eventCount === 1 ? "" : "s"}` : null,
+        verifiedLinkCount ? `${verifiedLinkCount} verified document link${verifiedLinkCount === 1 ? "" : "s"}` : null,
+      ].filter((item): item is string => Boolean(item));
+      return { node, score: node.eventCount * 3 + verifiedLinkCount * 2, verifiedLinkCount, reasons };
+    })
+    .filter((item) => item.score > 0)
+    .sort((left, right) => right.score - left.score || left.node.date.localeCompare(right.node.date))
+    .slice(0, 8)
+    .map(({ node, verifiedLinkCount, reasons }) => ({
+      documentId: node.id,
+      date: node.date,
+      title: node.title,
+      reason: reasons.join(" and "),
+      verifiedLinkCount,
+      eventCount: node.eventCount,
+    }));
+}
+
 export function buildCaseReconstruction(options: {
   documents: ReconstructionDocument[];
   events: ReconstructionEvent[];
@@ -412,5 +546,14 @@ export function buildCaseReconstruction(options: {
       : null,
   ].filter((item): item is string => Boolean(item));
 
-  return { schemaVersion: 2, nodes, edges, routes, warnings };
+  return {
+    schemaVersion: 2,
+    nodes,
+    edges,
+    routes,
+    phases: buildPhases(nodes),
+    chains: buildChains(nodes, edges),
+    keyMoments: buildKeyMoments(nodes, edges),
+    warnings,
+  };
 }

--- a/src/renderer/components/CaseReconstruction.tsx
+++ b/src/renderer/components/CaseReconstruction.tsx
@@ -217,6 +217,8 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
     visibleNodeIds.has(edge.from) && visibleNodeIds.has(edge.to) &&
     (showInferred || edge.evidence === "explicit") && edge.confidence * 100 >= minimumConfidence) ?? [],
   [reconstruction, visibleNodeIds, showInferred, minimumConfidence]);
+  const visibleKeyMoments = useMemo(() => reconstruction?.keyMoments?.filter((moment) =>
+    visibleNodeIds.has(moment.documentId)) ?? [], [reconstruction, visibleNodeIds]);
   const tracedIds = useMemo(() => traceSelected ? connectedIds(selectedId, visibleEdges) : new Set<string>(),
     [traceSelected, selectedId, visibleEdges]);
   const selectedNode = reconstruction?.nodes.find((node) => node.id === selectedId) ?? null;
@@ -363,11 +365,11 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
               </button>
             ))}
           </div>
-          {reconstruction.keyMoments?.length ? (
+          {visibleKeyMoments.length ? (
             <div className="mt-4">
               <h4 className="text-xs font-medium uppercase text-muted-foreground">Source-backed key moments</h4>
               <div className="mt-2 flex flex-wrap gap-2">
-                {reconstruction.keyMoments.map((moment) => (
+                {visibleKeyMoments.map((moment) => (
                   <button
                     key={moment.documentId}
                     type="button"

--- a/src/renderer/components/CaseReconstruction.tsx
+++ b/src/renderer/components/CaseReconstruction.tsx
@@ -58,6 +58,34 @@ type Reconstruction = {
   nodes: ReconstructionNode[];
   edges: ReconstructionEdge[];
   routes: Array<{ id: RouteId; label: string; documentCount: number; eventCount: number }>;
+  phases: Array<{
+    id: string;
+    label: string;
+    startDate: string;
+    endDate: string;
+    documentIds: string[];
+    documentCount: number;
+    eventCount: number;
+    summary: string;
+  }>;
+  chains: Array<{
+    id: string;
+    documentIds: string[];
+    edgeIds: string[];
+    startDate: string;
+    endDate: string;
+    explicitLinkCount: number;
+    inferredLinkCount: number;
+    confidence: number;
+  }>;
+  keyMoments: Array<{
+    documentId: string;
+    date: string;
+    title: string;
+    reason: string;
+    verifiedLinkCount: number;
+    eventCount: number;
+  }>;
   warnings: string[];
 };
 
@@ -306,6 +334,56 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
         ))}
         <span className="flex items-center gap-2"><span className="w-6 border-t-2 border-dashed border-slate-500" /> Suggested relationship</span>
       </div>
+
+      {reconstruction.phases?.length ? (
+        <section className="border-y border-border/60 py-4" aria-labelledby="reconstruction-story-title">
+          <div className="flex flex-wrap items-end justify-between gap-2">
+            <div>
+              <h3 id="reconstruction-story-title" className="text-sm font-semibold">Documented story</h3>
+              <p className="mt-1 text-xs text-muted-foreground">Neutral phases derived from document order. Select a phase or key moment to focus the source map.</p>
+            </div>
+            <span className="text-xs text-muted-foreground">{reconstruction.chains?.length ?? 0} connected chain{reconstruction.chains?.length === 1 ? "" : "s"}</span>
+          </div>
+          <div className="mt-3 grid gap-2 md:grid-cols-3">
+            {reconstruction.phases.map((phase) => (
+              <button
+                key={phase.id}
+                type="button"
+                className="border border-border/70 p-3 text-left hover:bg-muted/40"
+                onClick={() => {
+                  setRouteFilter("all");
+                  setFocusFilter("all");
+                  setSelectedId(phase.documentIds[0] ?? null);
+                  setTraceSelected(false);
+                }}
+              >
+                <span className="block text-xs text-muted-foreground">{formatDate(phase.startDate)}{phase.endDate !== phase.startDate ? ` - ${formatDate(phase.endDate)}` : ""}</span>
+                <span className="mt-1 block text-sm font-medium">{phase.label}</span>
+                <span className="mt-1 block text-xs leading-5 text-muted-foreground">{phase.summary}</span>
+              </button>
+            ))}
+          </div>
+          {reconstruction.keyMoments?.length ? (
+            <div className="mt-4">
+              <h4 className="text-xs font-medium uppercase text-muted-foreground">Source-backed key moments</h4>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {reconstruction.keyMoments.map((moment) => (
+                  <button
+                    key={moment.documentId}
+                    type="button"
+                    className="border border-border/70 px-3 py-2 text-left hover:bg-muted/40"
+                    title={moment.reason}
+                    onClick={() => setSelectedId(moment.documentId)}
+                  >
+                    <span className="block text-xs font-medium">{moment.title}</span>
+                    <span className="block text-[11px] text-muted-foreground">{formatDate(moment.date)} - {moment.reason}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
 
       {!visibleNodes.length ? (
         <div className="border border-dashed border-border p-8 text-center">

--- a/src/renderer/components/CaseReconstruction.tsx
+++ b/src/renderer/components/CaseReconstruction.tsx
@@ -146,6 +146,8 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
   const [minimumConfidence, setMinimumConfidence] = useState(52);
   const [routeFilter, setRouteFilter] = useState<RouteId | "all">("all");
   const [focusFilter, setFocusFilter] = useState("all");
+  const [phaseFilter, setPhaseFilter] = useState("all");
+  const [chainFilter, setChainFilter] = useState("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [traceSelected, setTraceSelected] = useState(false);
   const [zoom, setZoom] = useState(1);
@@ -207,11 +209,19 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
   }, [reconstruction]);
   const visibleNodes = useMemo(() => reconstruction?.nodes.filter((node) => {
     if (routeFilter !== "all" && node.route !== routeFilter) return false;
+    if (phaseFilter !== "all") {
+      const phase = reconstruction.phases?.find((item) => item.id === phaseFilter);
+      if (phase && !phase.documentIds.includes(node.id)) return false;
+    }
+    if (chainFilter !== "all") {
+      const chain = reconstruction.chains?.find((item) => item.id === chainFilter);
+      if (chain && !chain.documentIds.includes(node.id)) return false;
+    }
     if (focusFilter === "all") return true;
     const [kind, ...parts] = focusFilter.split(":");
     const value = parts.join(":");
     return kind === "participant" ? node.participants.includes(value) : node.topics.includes(value);
-  }) ?? [], [reconstruction, routeFilter, focusFilter]);
+  }) ?? [], [reconstruction, routeFilter, focusFilter, phaseFilter, chainFilter]);
   const visibleNodeIds = useMemo(() => new Set(visibleNodes.map((node) => node.id)), [visibleNodes]);
   const visibleEdges = useMemo(() => reconstruction?.edges.filter((edge) =>
     visibleNodeIds.has(edge.from) && visibleNodeIds.has(edge.to) &&
@@ -351,10 +361,13 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
               <button
                 key={phase.id}
                 type="button"
-                className="border border-border/70 p-3 text-left hover:bg-muted/40"
+                className={`border p-3 text-left hover:bg-muted/40 ${phaseFilter === phase.id ? "border-foreground bg-muted/40" : "border-border/70"}`}
+                aria-pressed={phaseFilter === phase.id}
                 onClick={() => {
                   setRouteFilter("all");
                   setFocusFilter("all");
+                  setChainFilter("all");
+                  setPhaseFilter((current) => current === phase.id ? "all" : phase.id);
                   setSelectedId(phase.documentIds[0] ?? null);
                   setTraceSelected(false);
                 }}
@@ -365,6 +378,38 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
               </button>
             ))}
           </div>
+          {reconstruction.chains?.length ? (
+            <div className="mt-4">
+              <h4 className="text-xs font-medium uppercase text-muted-foreground">Connected document chains</h4>
+              <div className="mt-2 grid gap-2 lg:grid-cols-2">
+                {reconstruction.chains.map((chain, index) => (
+                  <button
+                    key={chain.id}
+                    type="button"
+                    className={`border p-3 text-left hover:bg-muted/40 ${chainFilter === chain.id ? "border-foreground bg-muted/40" : "border-border/70"}`}
+                    aria-pressed={chainFilter === chain.id}
+                    onClick={() => {
+                      setRouteFilter("all");
+                      setFocusFilter("all");
+                      setPhaseFilter("all");
+                      setChainFilter((current) => current === chain.id ? "all" : chain.id);
+                      setSelectedId(chain.documentIds[0] ?? null);
+                      setTraceSelected(false);
+                    }}
+                  >
+                    <span className="flex flex-wrap items-center justify-between gap-2 text-sm font-medium">
+                      <span>Chain {index + 1} - {chain.documentIds.length} documents</span>
+                      <Badge variant="outline">{Math.round(chain.confidence * 100)}% average confidence</Badge>
+                    </span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      {formatDate(chain.startDate)}{chain.endDate !== chain.startDate ? ` - ${formatDate(chain.endDate)}` : ""}
+                      {" - "}{chain.explicitLinkCount} verified, {chain.inferredLinkCount} suggested
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
           {visibleKeyMoments.length ? (
             <div className="mt-4">
               <h4 className="text-xs font-medium uppercase text-muted-foreground">Source-backed key moments</h4>
@@ -375,7 +420,13 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
                     type="button"
                     className="border border-border/70 px-3 py-2 text-left hover:bg-muted/40"
                     title={moment.reason}
-                    onClick={() => setSelectedId(moment.documentId)}
+                    onClick={() => {
+                      setRouteFilter("all");
+                      setFocusFilter("all");
+                      setPhaseFilter("all");
+                      setChainFilter("all");
+                      setSelectedId(moment.documentId);
+                    }}
                   >
                     <span className="block text-xs font-medium">{moment.title}</span>
                     <span className="block text-[11px] text-muted-foreground">{formatDate(moment.date)} - {moment.reason}</span>
@@ -391,7 +442,12 @@ export function CaseReconstruction({ caseId }: { caseId: string }) {
         <div className="border border-dashed border-border p-8 text-center">
           <Focus className="mx-auto h-8 w-8 text-muted-foreground" />
           <h3 className="mt-3 font-medium">No documents match this focus</h3>
-          <Button type="button" variant="outline" size="sm" className="mt-3" onClick={() => { setRouteFilter("all"); setFocusFilter("all"); }}>Clear filters</Button>
+          <Button type="button" variant="outline" size="sm" className="mt-3" onClick={() => {
+            setRouteFilter("all");
+            setFocusFilter("all");
+            setPhaseFilter("all");
+            setChainFilter("all");
+          }}>Clear filters</Button>
         </div>
       ) : view === "map" ? (
         <ReconstructionMap

--- a/tests/backend/caseReconstruction.test.ts
+++ b/tests/backend/caseReconstruction.test.ts
@@ -97,6 +97,19 @@ describe("case document reconstruction", () => {
       expect.objectContaining({ from: "decision", to: "attachment", relationship: "attachment_of", evidence: "explicit", confidence: 1 }),
       expect.objectContaining({ from: "decision", to: "objection", relationship: "references", evidence: "explicit" }),
     ]));
+    expect(result.phases).toEqual([
+      expect.objectContaining({ label: "Opening record", documentIds: ["decision", "objection"], eventCount: 2 }),
+      expect.objectContaining({ label: "Later record", documentIds: ["attachment", "unanalyzed"] }),
+    ]);
+    expect(result.chains[0]).toMatchObject({
+      documentIds: expect.arrayContaining(["decision", "objection", "attachment"]),
+      explicitLinkCount: 2,
+    });
+    expect(result.keyMoments[0]).toMatchObject({
+      documentId: "decision",
+      verifiedLinkCount: 2,
+      eventCount: 1,
+    });
     expect(result.warnings.join(" ")).toContain("not been analyzed");
   });
 });


### PR DESCRIPTION
## What changed

- adds neutral, date-ordered document story phases
- identifies source-backed key moments using dated actions and verified links
- exposes connected document chains with explicit and inferred link counts
- expands the retirement audit across both predecessor branches
- documents deliberately excluded mock collectors and unsupported legal-probability scoring

## Impact

LARO now retains every production-safe capability from the Paper Trail Visualizer while keeping source provenance and inference boundaries explicit. The predecessor repository is no longer required once this PR is merged.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run typecheck:renderer`
- `npm.cmd exec -- vitest run tests/backend/caseReconstruction.test.ts tests/backend/documentIntelligence.test.ts` (5 tests passed)
- `git diff --check`

The broad stabilization gate exceeded the local 120-second execution window; focused compile and behavior checks passed.