### PR TITLE
Reject invalid Google provider secrets

### DIFF
--- a/scripts/configure-live-providers.ps1
+++ b/scripts/configure-live-providers.ps1
@@ -52,6 +52,21 @@ function Protect-Secret {
     return ConvertFrom-SecureString -SecureString $Value
 }
 
+function Assert-GoogleClientSecret {
+    param([Parameter(Mandatory)] [Security.SecureString]$Value)
+
+    $pointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Value)
+    try {
+        $plainText = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($pointer)
+        if ($plainText -notmatch "^[A-Za-z0-9_-]{16,128}$") {
+            throw "Google client secret must be the token from Google Cloud, not a URL, path, or placeholder."
+        }
+    } finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($pointer)
+        $plainText = $null
+    }
+}
+
 function Normalize-SmtpPassword {
     param(
         [Parameter(Mandatory)] [Security.SecureString]$Value,
@@ -150,6 +165,7 @@ if ($Google) {
     if (-not $GoogleClientSecret -or $GoogleClientSecret.Length -lt 16) {
         throw "Google client secret is missing or too short."
     }
+    Assert-GoogleClientSecret -Value $GoogleClientSecret
     $config.google = [ordered]@{
         clientId = $GoogleClientId
         clientSecretProtected = Protect-Secret -Value $GoogleClientSecret

--- a/scripts/start-ngrok-api.ps1
+++ b/scripts/start-ngrok-api.ps1
@@ -79,6 +79,20 @@ function Unprotect-Secret {
     }
 }
 
+function Assert-GoogleProviderConfig {
+    param(
+        [Parameter(Mandatory)] [string]$ClientId,
+        [Parameter(Mandatory)] [string]$ClientSecret
+    )
+
+    if ($ClientId -notmatch "^[0-9]+-[a-z0-9-]+\.apps\.googleusercontent\.com$") {
+        throw "Protected Google provider configuration contains an invalid web OAuth client ID."
+    }
+    if ($ClientSecret -notmatch "^[A-Za-z0-9_-]{16,128}$") {
+        throw "Protected Google provider configuration contains an invalid client secret. Reconfigure Google before deployment."
+    }
+}
+
 function Import-ProtectedProviderConfig {
     if (-not (Test-Path -LiteralPath $providerConfigPath)) { return }
 
@@ -90,8 +104,11 @@ function Import-ProtectedProviderConfig {
         if (-not $config.google.clientId -or -not $config.google.clientSecretProtected) {
             throw "Protected Google provider configuration is incomplete."
         }
+        $googleClientSecret = Unprotect-Secret -ProtectedValue $config.google.clientSecretProtected
+        Assert-GoogleProviderConfig -ClientId $config.google.clientId -ClientSecret $googleClientSecret
         $env:GOOGLE_CLIENT_ID = $config.google.clientId
-        $env:GOOGLE_CLIENT_SECRET = Unprotect-Secret -ProtectedValue $config.google.clientSecretProtected
+        $env:GOOGLE_CLIENT_SECRET = $googleClientSecret
+        $googleClientSecret = $null
     }
     if ($config.outboundEmail) {
         if (

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -365,6 +365,10 @@ describe('production readiness regressions', () => {
     expect(ngrokStopper).toContain('$processDetails.CommandLine -notmatch "laro-api"');
     expect(ngrokStopper).toContain('docker compose stop laro-server');
     expect(providerSetup).toContain('Read-Host "Google web OAuth client secret" -AsSecureString');
+    expect(providerSetup).toContain('Assert-GoogleClientSecret -Value $GoogleClientSecret');
+    expect(providerSetup).toContain('not a URL, path, or placeholder');
+    expect(ngrokLauncher).toContain('Assert-GoogleProviderConfig');
+    expect(ngrokLauncher).toContain('Reconfigure Google before deployment');
     expect(providerSetup).toContain('Read-Host "SMTP password or Gmail app password" -AsSecureString');
     expect(providerSetup).toContain('ConvertFrom-SecureString -SecureString $Value');
     expect(providerSetup).toContain('/inheritance:r');


### PR DESCRIPTION
## What changed
- validate Google OAuth client secrets before storing protected provider configuration
- fail closed when ngrok deployment imports an invalid Google client ID or secret
- add production-readiness regression coverage for both checks

## Why
The restored deployment contained a repository URL in the Google client-secret field. Presence-only validation allowed the deployment to appear configured while OAuth could never succeed.

## Impact
Invalid URLs, paths, and placeholders now fail before Docker/ngrok startup. Existing valid token-shaped secrets continue to load through Windows DPAPI.

## Verification
- `npm.cmd test` (59 files, 368 tests)
- `npm.cmd run readiness`
- `git diff --check`