### PR TITLE
Pin API deployment Compose project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ HOST=127.0.0.1
 # API-only deployments disable renderer file serving. The ngrok launcher sets
 # this through Docker Compose and keeps the container bound to host loopback.
 SERVER_ONLY=false
+# Stable Docker Compose identity for API deployments. Keep this value unchanged
+# across checkout-folder moves so the same named data volume is reused.
+LARO_COMPOSE_PROJECT_NAME=laro
 # Explicit browser origins allowed to call the credentialed API. Never use *.
 ALLOWED_ORIGINS=
 # Optional public gateway prefix for shared-domain API deployments.

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Agent Endpoint:
 
 ```powershell
 .\scripts\start-ngrok-api.ps1 `
+  -ComposeProjectName laro `
   -GatewayUrl https://example.ngrok-free.dev `
   -PathPrefix /laro
 
@@ -301,6 +302,11 @@ publish the Electron interface. Register
 `https://example.ngrok-free.dev/laro/api/oauth/gmail/callback` on the Google web
 OAuth client. See [Deployment](docs/DEPLOYMENT.md) for the exact traffic-policy,
 secret-handling, and verification requirements.
+
+Keep `LARO_COMPOSE_PROJECT_NAME` stable across checkout-folder moves. The
+launcher passes it explicitly to Docker Compose so restarts reuse the intended
+`laro-data` volume instead of silently creating an empty volume under a new
+folder-derived project name.
 
 On Windows, configure live Google and SMTP secrets through DPAPI-protected,
 non-echoing prompts instead of placing them in `.env`:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -59,6 +59,7 @@ another application, LARO uses a private `laro.internal` endpoint and an exact
 ```powershell
 # First run builds the image. A configured ngrok account is required.
 .\scripts\start-ngrok-api.ps1 `
+  -ComposeProjectName laro `
   -GatewayUrl https://example.ngrok-free.dev `
   -PathPrefix /laro
 ```
@@ -66,6 +67,9 @@ another application, LARO uses a private `laro.internal` endpoint and an exact
 The command creates strong standalone `JWT_SECRET` and `COOKIE_SECRET` values
 in the ignored local `.env` when they are absent. It never commits or prints
 them. Provider credentials remain owner-supplied secrets in that ignored file.
+It also persists `LARO_COMPOSE_PROJECT_NAME`; keep that value unchanged when
+moving or refreshing the checkout so Docker Compose reuses the intended named
+database volume.
 Runtime URL/PID metadata is written to ignored `.laro-ngrok.json`. Install
 `ngrok/laro-path-policy.yml` on the existing public Agent Endpoint once; the
 launcher then verifies `https://<dev-domain>/laro/api/health` on every start.

--- a/scripts/start-ngrok-api.ps1
+++ b/scripts/start-ngrok-api.ps1
@@ -3,6 +3,7 @@ param(
     [string]$GatewayUrl = "",
     [string]$PathPrefix = "",
     [string]$InternalUrl = "",
+    [string]$ComposeProjectName = "",
     [switch]$SkipBuild,
     [switch]$SkipPublicCheck
 )
@@ -202,6 +203,16 @@ foreach ($name in "JWT_SECRET", "COOKIE_SECRET") {
 Set-EnvValue -Path $envPath -Name "NODE_ENV" -Value "production"
 Import-ProtectedProviderConfig
 
+$configuredComposeProject = Get-EnvValue -Path $envPath -Name "LARO_COMPOSE_PROJECT_NAME"
+if (-not $ComposeProjectName) {
+    $ComposeProjectName = if ($configuredComposeProject) { $configuredComposeProject } else { "laro" }
+}
+$ComposeProjectName = $ComposeProjectName.Trim().ToLowerInvariant()
+if ($ComposeProjectName -notmatch "^[a-z0-9][a-z0-9_-]*$") {
+    throw "ComposeProjectName must use lowercase letters, digits, dashes, or underscores."
+}
+Set-EnvValue -Path $envPath -Name "LARO_COMPOSE_PROJECT_NAME" -Value $ComposeProjectName
+
 if (-not $GatewayUrl) { $GatewayUrl = Get-EnvValue -Path $envPath -Name "LARO_NGROK_GATEWAY_URL" }
 if (-not $PathPrefix) { $PathPrefix = Get-EnvValue -Path $envPath -Name "LARO_NGROK_PATH_PREFIX" }
 if (-not $InternalUrl) { $InternalUrl = Get-EnvValue -Path $envPath -Name "LARO_NGROK_INTERNAL_URL" }
@@ -294,7 +305,7 @@ try {
     $env:LARO_PUBLIC_BASE_URL = $publicBaseUrl
     $env:LARO_PUBLIC_PATH_PREFIX = $normalizedPrefix
 
-    $composeArguments = @("compose", "up", "-d")
+    $composeArguments = @("compose", "-p", $ComposeProjectName, "up", "-d")
     if (-not $SkipBuild) { $composeArguments += "--build" }
     & docker @composeArguments
     if ($LASTEXITCODE -ne 0) { throw "Docker Compose failed to start LARO." }
@@ -316,6 +327,7 @@ try {
         healthUrl = "$publicBaseUrl/api/health"
         internalUrl = $httpsTunnel.public_url
         ngrokPid = $ngrokProcess.Id
+        composeProjectName = $ComposeProjectName
         startedAt = (Get-Date).ToUniversalTime().ToString("o")
         version = $localHealth.version
         publicVerified = [bool]$publicHealth

--- a/scripts/stop-ngrok-api.ps1
+++ b/scripts/stop-ngrok-api.ps1
@@ -1,5 +1,6 @@
 [CmdletBinding()]
 param(
+    [string]$ComposeProjectName = "",
     [switch]$KeepContainer
 )
 
@@ -8,6 +9,23 @@ $root = Split-Path -Parent $PSScriptRoot
 $runtimePath = Join-Path $root ".laro-ngrok.json"
 
 Set-Location -LiteralPath $root
+
+function Get-EnvValue {
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] [string]$Name
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) { return "" }
+    $entry = Get-Content -LiteralPath $Path |
+        Where-Object { $_ -match "^$([regex]::Escape($Name))=" } |
+        Select-Object -Last 1
+    if (-not $entry) { return "" }
+    return ($entry -split "=", 2)[1].Trim()
+}
+
+$envPath = Join-Path $root ".env"
+$runtime = $null
 
 if (Test-Path -LiteralPath $runtimePath) {
     $runtime = Get-Content -LiteralPath $runtimePath -Raw | ConvertFrom-Json
@@ -28,11 +46,23 @@ if (Test-Path -LiteralPath $runtimePath) {
     Remove-Item -LiteralPath $runtimePath -Force
 }
 
+if (-not $ComposeProjectName -and $runtime.composeProjectName) {
+    $ComposeProjectName = [string]$runtime.composeProjectName
+}
+if (-not $ComposeProjectName) {
+    $ComposeProjectName = Get-EnvValue -Path $envPath -Name "LARO_COMPOSE_PROJECT_NAME"
+}
+if (-not $ComposeProjectName) { $ComposeProjectName = "laro" }
+$ComposeProjectName = $ComposeProjectName.Trim().ToLowerInvariant()
+if ($ComposeProjectName -notmatch "^[a-z0-9][a-z0-9_-]*$") {
+    throw "ComposeProjectName must use lowercase letters, digits, dashes, or underscores."
+}
+
 if (-not $KeepContainer) {
     if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
         throw "docker is required but was not found on PATH."
     }
-    & docker compose stop laro-server
+    & docker compose -p $ComposeProjectName stop laro-server
     if ($LASTEXITCODE -ne 0) { throw "Docker Compose failed to stop LARO." }
 }
 

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -363,12 +363,15 @@ describe('production readiness regressions', () => {
     expect(ngrokLauncher).toContain('Unprotect-Secret -ProtectedValue');
     expect(ngrokStopper).toContain('$process.ProcessName -ne "ngrok"');
     expect(ngrokStopper).toContain('$processDetails.CommandLine -notmatch "laro-api"');
-    expect(ngrokStopper).toContain('docker compose stop laro-server');
+    expect(ngrokStopper).not.toContain('docker compose stop laro-server');
     expect(providerSetup).toContain('Read-Host "Google web OAuth client secret" -AsSecureString');
     expect(providerSetup).toContain('Assert-GoogleClientSecret -Value $GoogleClientSecret');
     expect(providerSetup).toContain('not a URL, path, or placeholder');
     expect(ngrokLauncher).toContain('Assert-GoogleProviderConfig');
     expect(ngrokLauncher).toContain('Reconfigure Google before deployment');
+    expect(ngrokLauncher).toContain('@("compose", "-p", $ComposeProjectName, "up", "-d")');
+    expect(ngrokLauncher).toContain('composeProjectName = $ComposeProjectName');
+    expect(ngrokStopper).toContain('docker compose -p $ComposeProjectName stop laro-server');
     expect(providerSetup).toContain('Read-Host "SMTP password or Gmail app password" -AsSecureString');
     expect(providerSetup).toContain('ConvertFrom-SecureString -SecureString $Value');
     expect(providerSetup).toContain('/inheritance:r');


### PR DESCRIPTION
## What changed
- add a stable, validated Compose project name to the ngrok start and stop scripts
- persist the project identity in `.env` and runtime metadata
- document the volume-reuse requirement and add regression coverage

## Why
The launcher previously let Docker Compose derive its project name from the checkout folder. Moving or refreshing a checkout could silently create an empty `laro-data` volume, while an existing deployment could also collide on port 3000.

## Impact
API restarts now target the intended named Docker volume regardless of checkout folder. The stop script uses the same persisted identity.

## Verification
- PowerShell parser: start/stop scripts syntax clean
- `npm.cmd test -- tests/security/productionReadiness.test.ts` (34 tests)
- `npm.cmd run readiness`
- `git diff --check`