### PR TITLE
Clear stale ngrok runtime metadata

### DIFF
--- a/scripts/start-ngrok-api.ps1
+++ b/scripts/start-ngrok-api.ps1
@@ -345,5 +345,8 @@ try {
     if ($startedNgrok -and -not $ngrokProcess.HasExited) {
         Stop-Process -Id $ngrokProcess.Id -Force -ErrorAction SilentlyContinue
     }
+    if ($startedNgrok) {
+        Remove-Item -LiteralPath $runtimePath -Force -ErrorAction SilentlyContinue
+    }
     throw
 }

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -371,6 +371,7 @@ describe('production readiness regressions', () => {
     expect(ngrokLauncher).toContain('Reconfigure Google before deployment');
     expect(ngrokLauncher).toContain('@("compose", "-p", $ComposeProjectName, "up", "-d")');
     expect(ngrokLauncher).toContain('composeProjectName = $ComposeProjectName');
+    expect(ngrokLauncher).toContain('Remove-Item -LiteralPath $runtimePath -Force -ErrorAction SilentlyContinue');
     expect(ngrokStopper).toContain('docker compose -p $ComposeProjectName stop laro-server');
     expect(providerSetup).toContain('Read-Host "SMTP password or Gmail app password" -AsSecureString');
     expect(providerSetup).toContain('ConvertFrom-SecureString -SecureString $Value');


### PR DESCRIPTION
## What changed
- remove saved ngrok runtime metadata when a newly started tunnel fails verification and is stopped
- add a production-readiness regression assertion

## Why
A failed public gateway check correctly stopped the fresh tunnel but left an older `.laro-ngrok.json` marker claiming the deployment was publicly verified.

## Impact
Operators no longer see stale green runtime state after a failed tunnel start. Existing/reused tunnels are not affected by this cleanup path.

## Verification
- PowerShell parser: syntax clean
- `npm.cmd test -- tests/security/productionReadiness.test.ts` (34 tests)
- `git diff --check`