### PR TITLE
Harden backup publication and refresh verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,14 @@ See [Operator Runbook](docs/OPERATOR_RUNBOOK.md), [Security](docs/SECURITY.md), 
 
 ## Verification
 
-The current production-readiness candidate was verified locally on 2026-07-21.
+The current production-readiness candidate was verified locally on 2026-08-01.
 GitHub Actions repeats the Node and browser checks on the supported Node 22 toolchain:
 
 - `npm run gate`: all blocking gates passed.
 - Server, Electron main-process, and shipped renderer TypeScript checks passed; no shipped runtime module disables type checking; ESLint passed.
 - Traceability reported 117 rows, 92 cited, and 0 broken references.
 - Runtime no-excuses scan reported 0 suspect findings; account safety reported 0 high-severity findings.
-- Vitest reported 55 passing files and 354 passing tests, including controlled
+- Vitest reported 59 passing files and 368 passing tests, including controlled
   NOvA parsing/filter, unknown-metric scoring, and review-gated
   media/organization discovery, tenant isolation, case-draft persistence, and
   target-database readiness tests, with no skipped or todo tests.
@@ -239,7 +239,7 @@ desktop server to that registered OAuth callback port instead.
 - A packaged launch from a directory containing hostile development `.env` values still reported production mode, database readiness, and a random `127.0.0.1` port.
 - Every protected-main commit must pass the Node, Python, renderer-accessibility,
   and Windows packaging workflows. Use the latest successful
-  [GitHub Actions runs](https://github.com/Noodzakelijk-Online/000-LARO/actions)
+  [GitHub Actions runs](https://github.com/Robert-Velhorst/000-LARO/actions)
   for commit-specific evidence instead of relying on a hash from an older build.
 - The Windows workflow publishes `LARO-Desktop-Windows` with the portable
   executable and its `.sha256` sidecar. It also verifies the production gate,

--- a/docs/FINAL_VERIFICATION_REPORT.md
+++ b/docs/FINAL_VERIFICATION_REPORT.md
@@ -1,7 +1,7 @@
 # Final Verification Report
 
-Date: 2026-07-21
-Verification target: protected `main` commit `21fc0135ec06568b05c12866faf38fa017a6c041`
+Date: 2026-08-01
+Verification target: protected `main` commit `5dd3c7612a1730f2e9b7db02b7be47db25ef1359`
 
 This report separates reproducible repository evidence from target-environment
 acceptance. It supersedes the 2026-07-06 phase snapshot.
@@ -18,7 +18,7 @@ acceptance. It supersedes the 2026-07-06 phase snapshot.
 | Renderer accessibility | 15 routes x 2 viewports; 0 serious/critical axe violations, unnamed controls, overflows, request failures, page errors, or console errors |
 | Isolated backup/delete/restore/reopen drill | Pass |
 | Target database readiness | SQLite integrity, declared foreign keys, 237 legacy relationship guards, invariants, reconciliation, duplicates, and demo markers clean |
-| Vitest | 53 files, 340 tests passed, 0 todo |
+| Vitest | 59 files, 368 tests passed, 0 todo |
 | Python unittest discovery | 222 tests passed |
 | Runtime dependency audit | 0 known vulnerabilities |
 | Renderer, main, and server production builds | Pass |
@@ -27,15 +27,21 @@ acceptance. It supersedes the 2026-07-06 phase snapshot.
 | Packaged document intelligence and Outreach | Seven migrations present, including persisted keyword-pull jobs and the legacy-import archive; PDF, DOCX, native parser dependencies, and review-gated Outreach tables present; integrated server booted successfully |
 | Desktop scanner contract | Scoped 15-minute token; real bytes/hash; owner/MIME enforcement |
 | Branch CI policy | Node, Python, and renderer-accessibility checks run before merge |
-| Protected-main baseline CI | Actions run `29819449370`; Node, Python, and renderer-accessibility jobs passed |
-| Windows package baseline | Actions run `29819449360`; gate, build, ABI check, package, single-instance profile lock, checksum, and artifact upload passed |
+| Protected-main baseline CI | Actions run `30693140677`; Node, Python, and renderer-accessibility jobs passed |
+| Windows package baseline | Actions run `30693140665`; gate, build, ABI check, package, single-instance profile lock, checksum, and artifact upload passed |
 | Packaged matching assets | Seven aligned legal categories; invalid legacy dataset absent |
 | Dependency graph | One canonical Node workspace; 0 open Dependabot alerts |
 
-`npm run readiness:production` passed with strong target-like secrets and an
-explicit clean target database. The readiness command restores the Node SQLite
-ABI itself after Electron packaging, runs the data-readiness gate, and preserves
-complete stdout/stderr for any failed step.
+`npm run readiness:production` passed both with strong target-like secrets and
+with the current API deployment's standalone secrets plus an integrity-checked
+snapshot of its clean target database. The readiness command restores the Node
+SQLite ABI itself after Electron packaging, runs the data-readiness gate, and
+preserves complete stdout/stderr for any failed step.
+
+A manifest-bound target recovery set was then created and validated against the
+current standalone JWT secret. Validation covered 54 tables and complete local
+evidence storage; publication and validation left no untracked SQLite temporary,
+WAL, or shared-memory sidecars.
 
 ## Packaged UI evidence
 
@@ -119,13 +125,22 @@ dark-theme recommendation contrast defect found during this pass was corrected
 and visually rechecked.
 
 The current protected-main portable artifact is GitHub Actions artifact
-`8490999899` from run `29819449360`. Its executable is 151,837,682 bytes with
-SHA-256 `758e15fdecc83d03f66d83d0933c4224476b123c001039eb62b30be95b4a568b`;
+`8816485204` from run `30693140665`. Its executable is 151,891,123 bytes with
+SHA-256 `14a27ff42c06d5cf1aa8897c605943b38ccc7d2e67675b7d27aeaa0e3714050c`;
 the downloaded executable matches its packaged checksum sidecar. The workflow
 passed the production gate, build, Electron ABI/database-binding check,
 portable packaging, packaged single-instance profile lock, artifact staging,
 and upload. Windows reports `NotSigned`, matching the selected unsigned
 internal distribution policy.
+
+The API-only Docker deployment was rebuilt on Node 22 from the current release
+line while retaining its explicitly named data volume. Local `/api/live`,
+`/api/ready`, and `/api/health` checks pass, the reported version is `1.3.0`,
+and SMTP authentication succeeds without sending a message. Google remains
+unconfigured because the previously stored value was not a Google client
+secret. The ngrok `/laro` gateway currently falls through to another service,
+so no public-API acceptance is claimed until that route is repaired and
+reverified.
 
 Packaged clean-profile evidence for this release line also verified fresh local
 secrets and databases, all seven packaged migrations, healthy version `1.3.0`

--- a/docs/MANUAL_VERIFICATION.md
+++ b/docs/MANUAL_VERIFICATION.md
@@ -1,6 +1,6 @@
 # Manual Verification Evidence
 
-Current as of 2026-07-21. This document supersedes the 2026-07-06 phase
+Current as of 2026-08-01. This document supersedes the 2026-07-06 phase
 snapshot; exact release evidence is maintained in
 `docs/FINAL_VERIFICATION_REPORT.md`.
 
@@ -21,12 +21,26 @@ snapshot; exact release evidence is maintained in
   list refresh, and scanner consent controls without console errors.
 - Packaging contents, SQLite schema, document parsers, matching data, checksum,
   and Windows signature state were inspected directly.
+- The current API deployment passes local live, ready, and health probes. Its
+  actual standalone secret configuration and a clean target-database snapshot
+  passed `npm run readiness:production`.
+- A complete manifest-bound target backup validates with 54 tables, the current
+  standalone secret compatibility tag, complete local evidence coverage, and no
+  untracked SQLite sidecars.
+- Gmail SMTP authentication was verified without sending a message. This proves
+  credentials only, not approved delivery, receipt, audit, or duplicate blocking.
+- Public branding is owner-approved and hash-bound in `release-acceptance.json`.
 
 ## Not Yet Verified
 
-- Production Google, outbound/inbound email, optional S3, and optional
-  provider-backed AI accounts have not completed target acceptance.
-- Public branding awaits owner confirmation.
+- Google and outbound email are the selected live-provider scope and have not
+  completed target acceptance. Google is currently unconfigured pending a valid
+  replacement OAuth client secret. Outbound delivery remains disabled pending
+  an approved single-delivery test and audit/idempotency verification.
+- The ngrok `/laro` public route currently falls through to another service;
+  only loopback API health is verified.
+- Optional inbound email, S3, and provider-backed AI are not selected for this
+  release and remain disabled rather than being treated as verified.
 - Trusted public Windows distribution is not selected; the supported artifact
   is unsigned and intended for internal delivery.
 

--- a/docs/NO_EXCUSES_SEARCH.md
+++ b/docs/NO_EXCUSES_SEARCH.md
@@ -37,7 +37,7 @@ Descriptive words (mock/stub/placeholder/fake) needing human judgement. Triage o
 | `server/_core/env.ts` | 96 | `* in production and the secrets are still the shipped placeholders (or empty),` |
 | `server/_core/env.ts` | 104 | `* to the insecure placeholder. Returns a list of non-fatal warnings (e.g.` |
 
-## Markers in tests / scripts / renderer (189) — reported, not failing
+## Markers in tests / scripts / renderer (190) — reported, not failing
 
 These are informational and do not identify unsupported runtime behavior by themselves; test/script occurrences are usually the words "mock"/"fake" used descriptively.
 
@@ -55,10 +55,10 @@ These are informational and do not identify unsupported runtime behavior by them
 | `src/renderer/components/AuthPage.tsx` | 5 |
 | `src/renderer/components/EvidenceFilters.tsx` | 5 |
 | `tests/backend/novaDirectory.test.ts` | 5 |
+| `tests/security/productionReadiness.test.ts` | 5 |
 | `src/renderer/components/EvidenceSearch.tsx` | 4 |
 | `tests/backend/outreachDirectory.test.ts` | 4 |
 | `tests/backend/realSend.test.ts` | 4 |
-| `tests/security/productionReadiness.test.ts` | 4 |
 | `src/renderer/components/CaseCreationWizard.tsx` | 3 |
 | `src/renderer/components/CommunicationLog.tsx` | 3 |
 | `src/renderer/components/EnhancedCaseDetailsDialog.tsx` | 3 |

--- a/server/backup.ts
+++ b/server/backup.ts
@@ -14,6 +14,26 @@ function currentDbPath(): string {
   return process.env.DATABASE_URL || "laro.sqlite";
 }
 
+export function cleanupBackupDatabaseSidecars(databasePath: string): void {
+  const source = path.resolve(databasePath);
+  for (const extension of ["-wal", "-shm"]) {
+    try {
+      if (fs.existsSync(source + extension)) fs.unlinkSync(source + extension);
+    } catch {
+      // The validation result remains authoritative; cleanup is best effort.
+    }
+  }
+}
+
+export function prepareBackupDatabaseRead(databasePath: string): void {
+  const source = path.resolve(databasePath);
+  const walPath = source + "-wal";
+  if (fs.existsSync(walPath) && fs.statSync(walPath).size > 0) {
+    throw new Error("Backup database has an untracked non-empty SQLite WAL sidecar.");
+  }
+  cleanupBackupDatabaseSidecars(source);
+}
+
 /** Create and verify a consistent online backup of the live database. */
 export async function backupDatabase(destPath: string): Promise<{ path: string; bytes: number }> {
   const db = await getDb();
@@ -39,9 +59,11 @@ export async function backupDatabase(destPath: string): Promise<{ path: string; 
 export function validateBackup(srcPath: string): { valid: boolean; reason?: string; tables?: string[] } {
   const source = path.resolve(srcPath);
   if (!fs.existsSync(source)) return { valid: false, reason: "File does not exist" };
+  const isLiveDatabase = source === path.resolve(currentDbPath());
 
   let probe: InstanceType<typeof Database> | null = null;
   try {
+    if (!isLiveDatabase) prepareBackupDatabaseRead(source);
     probe = new Database(source, { readonly: true, fileMustExist: true });
     const integrity = probe.pragma("quick_check") as Array<{ quick_check: string }>;
     if (integrity.length !== 1 || integrity[0]?.quick_check !== "ok") {
@@ -64,6 +86,7 @@ export function validateBackup(srcPath: string): { valid: boolean; reason?: stri
     return { valid: false, reason: error instanceof Error ? error.message : String(error) };
   } finally {
     try { probe?.close(); } catch { /* best effort */ }
+    if (!isLiveDatabase) cleanupBackupDatabaseSidecars(source);
   }
 }
 

--- a/server/backupStorage.ts
+++ b/server/backupStorage.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import Database from "better-sqlite3";
+import { cleanupBackupDatabaseSidecars, prepareBackupDatabaseRead } from "./backup";
 import { collectManagedStorageKeys } from "./managedStorage";
 import { sanitizeStorageKey } from "./storage";
 
@@ -127,7 +128,9 @@ function sameFiles(left: LocalStorageFileManifest[], right: LocalStorageFileMani
 }
 
 function managedStorageKeys(databasePath: string): string[] {
-  const database = new Database(path.resolve(databasePath), { readonly: true, fileMustExist: true });
+  const resolvedDatabasePath = path.resolve(databasePath);
+  prepareBackupDatabaseRead(resolvedDatabasePath);
+  const database = new Database(resolvedDatabasePath, { readonly: true, fileMustExist: true });
   try {
     return collectManagedStorageKeys(database, {})
       .map((key) => {
@@ -141,6 +144,7 @@ function managedStorageKeys(databasePath: string): string[] {
       .sort(compareText);
   } finally {
     database.close();
+    cleanupBackupDatabaseSidecars(resolvedDatabasePath);
   }
 }
 

--- a/tests/backend/backupSet.test.ts
+++ b/tests/backend/backupSet.test.ts
@@ -85,6 +85,11 @@ suite('recovery-ready backup sets', () => {
     )).toBe(originalEvidence);
     expect(validation.tables).toContain('evidence');
     expect(fs.readdirSync(app.tmpDir).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    expect(fs.existsSync(`${destination}-wal`)).toBe(false);
+    expect(fs.existsSync(`${destination}-shm`)).toBe(false);
+    expect(fs.readdirSync(app.tmpDir).filter(
+      (name) => name.startsWith('complete.sqlite.') && name.includes('.tmp-'),
+    )).toEqual([]);
   });
 
   it('refuses to overwrite any member of an existing backup set', async () => {
@@ -110,6 +115,14 @@ suite('recovery-ready backup sets', () => {
     expect(validateBackupSet(databaseTamper)).toMatchObject({
       valid: false,
       reason: expect.stringContaining('database hash or size'),
+    });
+
+    const sidecarTamper = path.join(app.tmpDir, 'sidecar-tamper.sqlite');
+    await createBackupSet(sidecarTamper, { desktopSecretsPath: secretsPath });
+    fs.writeFileSync(`${sidecarTamper}-wal`, 'untracked transaction bytes');
+    expect(validateBackupSet(sidecarTamper)).toMatchObject({
+      valid: false,
+      reason: expect.stringContaining('untracked non-empty SQLite WAL sidecar'),
     });
 
     const secretTamper = path.join(app.tmpDir, 'secret-tamper.sqlite');


### PR DESCRIPTION
## What changed
- reject backup databases that have an untracked non-empty SQLite WAL sidecar
- remove validation-created WAL/SHM files for backup and temporary database paths
- extend recovery-set tests to cover sidecar cleanup and untracked WAL rejection
- refresh README and verification evidence for the current production audit

## Why
A real target backup validated successfully but left SQLite sidecars beside both the published database and its temporary staging name. Those files were outside the recovery manifest and made the published set operationally ambiguous.

## Impact
Successful backup publication and validation now leave only manifest-tracked recovery members. A non-empty pre-existing WAL fails closed instead of allowing unmanifested transaction bytes to influence validation.

## Verification
- `npm.cmd run gate` (59 files, 368 tests; all blocking gates passed)
- focused backup suites (20 tests)
- server/main typecheck
- actual target backup and validation: 54 tables, complete local evidence, zero unexpected auxiliary files
- target `npm.cmd run readiness:production`
- runtime `npm audit --omit=dev`: zero vulnerabilities