### PR TITLE
Harden ngrok direct tunnel failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,10 @@ matching origin and OAuth settings, verifies the public health response, and
 persists direct mode for later `-SkipBuild` starts. An account-assigned direct
 URL can change after a tunnel restart; update the Google OAuth redirect URI to
 `https://<assigned-domain>/api/oauth/gmail/callback` before accepting Google
-connectivity. Use the gateway mode above for a stable production URL.
+connectivity. The assigned domain must also be available; accounts whose only
+dev domain already hosts another endpoint still require a gateway path rule or
+an additional assigned domain. Use the gateway mode above for a stable
+production URL.
 
 Keep `LARO_COMPOSE_PROJECT_NAME` stable across checkout-folder moves. The
 launcher passes it explicitly to Docker Compose so restarts reuse the intended

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -118,8 +118,11 @@ invoke the launcher with `-GatewayUrl`, `-PathPrefix`, and optionally
 `-InternalUrl`.
 
 The assigned direct URL may change after the ngrok process stops. Treat it as
-an operational fallback, not as a stable production hostname. Before Google
-OAuth acceptance, register the current callback exactly as:
+an operational fallback, not as a stable production hostname. The account must
+have an available assigned domain; if its only dev domain is already online,
+ngrok rejects the direct tunnel rather than replacing or pooling with that
+endpoint. In that case, install the gateway path rule or assign another domain.
+Before Google OAuth acceptance, register the current callback exactly as:
 
 ```text
 https://<assigned-domain>/api/oauth/gmail/callback

--- a/scripts/start-ngrok-api.ps1
+++ b/scripts/start-ngrok-api.ps1
@@ -14,7 +14,7 @@ $root = Split-Path -Parent $PSScriptRoot
 $envPath = Join-Path $root ".env"
 $runtimePath = Join-Path $root ".laro-ngrok.json"
 $providerConfigPath = Join-Path $root ".laro-provider-config.json"
-$ngrokLogPath = Join-Path $env:TEMP "laro-ngrok.log"
+$ngrokLogPath = Join-Path $env:TEMP "laro-ngrok-$PID.log"
 
 function Set-EnvValue {
     param(
@@ -149,6 +149,23 @@ function Wait-ForJsonEndpoint {
     }
 }
 
+function Get-NgrokFailureMessage {
+    if (-not (Test-Path -LiteralPath $ngrokLogPath)) { return "" }
+
+    try {
+        $failure = Get-Content -LiteralPath $ngrokLogPath |
+            ForEach-Object {
+                try { $_ | ConvertFrom-Json } catch { $null }
+            } |
+            Where-Object { $_.err -and $_.lvl -in "eror", "crit" } |
+            Select-Object -Last 1
+        if (-not $failure) { return "" }
+        return (($failure.err -split "`r?`n", 2)[0]).Trim()
+    } catch {
+        return ""
+    }
+}
+
 function Wait-ForHttpsTunnel {
     param(
         [Parameter(Mandatory)] [Diagnostics.Process]$Process,
@@ -158,6 +175,10 @@ function Wait-ForHttpsTunnel {
 
     for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
         if ($Process.HasExited) {
+            $failureMessage = Get-NgrokFailureMessage
+            if ($failureMessage) {
+                throw "ngrok exited before registering an HTTPS tunnel: $failureMessage"
+            }
             throw "ngrok exited before registering an HTTPS tunnel."
         }
         try {
@@ -230,7 +251,6 @@ if ($useDirectTunnel) {
     if ($GatewayUrl -or $PathPrefix -or $InternalUrl) {
         throw "DirectPublicTunnel cannot be combined with GatewayUrl, PathPrefix, or InternalUrl."
     }
-    Set-EnvValue -Path $envPath -Name "LARO_NGROK_MODE" -Value "direct"
 } else {
     if (-not $GatewayUrl) { $GatewayUrl = Get-EnvValue -Path $envPath -Name "LARO_NGROK_GATEWAY_URL" }
     if (-not $PathPrefix) { $PathPrefix = Get-EnvValue -Path $envPath -Name "LARO_NGROK_PATH_PREFIX" }
@@ -269,7 +289,6 @@ if ($useDirectTunnel) {
         throw "InternalUrl must be an HTTPS ngrok internal endpoint."
     }
 
-    Set-EnvValue -Path $envPath -Name "LARO_NGROK_MODE" -Value "gateway"
     Set-EnvValue -Path $envPath -Name "LARO_NGROK_GATEWAY_URL" -Value $publicOrigin
     Set-EnvValue -Path $envPath -Name "LARO_NGROK_PATH_PREFIX" -Value $normalizedPrefix
     Set-EnvValue -Path $envPath -Name "LARO_NGROK_INTERNAL_URL" -Value $InternalUrl
@@ -365,6 +384,11 @@ try {
             throw "LARO public health verification did not report healthy."
         }
     }
+
+    Set-EnvValue `
+        -Path $envPath `
+        -Name "LARO_NGROK_MODE" `
+        -Value $(if ($useDirectTunnel) { "direct" } else { "gateway" })
 
     [ordered]@{
         mode = if ($useDirectTunnel) { "direct" } else { "gateway" }

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -360,6 +360,11 @@ describe('production readiness regressions', () => {
     expect(ngrokLauncher).toContain('[switch]$DirectPublicTunnel');
     expect(ngrokLauncher).toContain('LARO_NGROK_MODE');
     expect(ngrokLauncher).toContain('DirectPublicTunnel cannot be combined');
+    expect(ngrokLauncher).toContain('Get-NgrokFailureMessage');
+    expect(ngrokLauncher).toContain('ngrok exited before registering an HTTPS tunnel: $failureMessage');
+    expect(ngrokLauncher.lastIndexOf('-Name "LARO_NGROK_MODE"')).toBeGreaterThan(
+      ngrokLauncher.indexOf('Wait-ForJsonEndpoint -Uri "$publicBaseUrl/api/health"'),
+    );
     expect(ngrokLauncher).toContain('$publicBaseUrl = $publicOrigin');
     expect(ngrokLauncher).toContain('mode = if ($useDirectTunnel) { "direct" } else { "gateway" }');
     expect(ngrokLauncher).toContain('LARO_NGROK_GATEWAY_URL');


### PR DESCRIPTION
## What changed
- persist direct or gateway mode only after runtime health checks complete
- use a per-launch ngrok log and surface the current actionable ngrok error
- document the single-assigned-domain limitation for direct mode
- add regression coverage for deferred mode persistence and failure detail

## Root cause
The direct-mode launcher wrote `LARO_NGROK_MODE=direct` before ngrok had registered an endpoint. A failed tunnel could therefore make later no-argument starts retry a mode that had never succeeded. The fixed shared log also made the generic process-exit message less useful.

## Validation
- real account failure reproduced with `ERR_NGROK_334`; no Docker change or stale runtime marker
- PowerShell parser: pass
- focused production-readiness suite: 34/34
- `npm run gate`: pass
- full Vitest suite: 59 files, 368 tests
- backup/restore and Flask recovery drills: pass