### PR TITLE
Expose API service status at root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ versioning; dates are ISO. Version is sourced from `package.json` and surfaced b
   compact source controls that open the owning document.
 
 ### Fixed
+- Made the advertised API-only base URL return a versioned service-status
+  document instead of a generic 404, while leaving desktop renderer routing
+  unchanged.
 - Closed unrestricted signup on public API-only deployments: a new database now
   requires a one-time strong bootstrap token for its first administrator and
   atomically closes enrollment after that owner exists. Desktop signup remains

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -80,6 +80,8 @@ from `.env` after bootstrap. Electron desktop signup does not use this token.
 Runtime URL/PID metadata is written to ignored `.laro-ngrok.json`. Install
 `ngrok/laro-path-policy.yml` on the existing public Agent Endpoint once; the
 launcher then verifies `https://<dev-domain>/laro/api/health` on every start.
+Opening `https://<dev-domain>/laro` returns a small JSON service-status document;
+the API-only deployment intentionally does not serve the desktop renderer.
 The validated gateway settings are retained in the ignored `.env`, so later
 starts need no arguments. The launcher also reuses a healthy LARO tunnel.
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -151,6 +151,20 @@ app.get('/api/health', async (_req, res) => {
 
 // ─── OAuth2 routes ────────────────────────────────────────────────────────────
 
+if (ENV.SERVER_ONLY) {
+  app.get('/', (_req, res) => {
+    res.status(200).json({
+      service: 'LARO API',
+      status: 'available',
+      version: APP_VERSION,
+      endpoints: {
+        health: 'api/health',
+        rpc: 'api/trpc',
+      },
+    });
+  });
+}
+
 // Mount OAuth2 callback routes
 app.use(oauth2CallbacksRouter);
 


### PR DESCRIPTION
## Summary
- return a versioned JSON service status from the API-only base URL
- identify the health and tRPC endpoint paths
- keep desktop renderer routing unchanged

## Verification
- server, main, and renderer typechecks
- ESLint
- server build
- npm audit: 0 vulnerabilities
- isolated Node 22 production container root and health acceptance