### PR TITLE
Skip Windows packaging for documentation-only pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   workflow_dispatch:
 
 permissions:

--- a/docs/MAINTENANCE_PLAN.md
+++ b/docs/MAINTENANCE_PLAN.md
@@ -12,6 +12,11 @@ Current as of 2026-07-16.
 | Every release | Run `npm run readiness:production`, package, launch with isolated user data, probe health, and record checksum. |
 | Quarterly | Review dependencies, rotate live-provider credentials, and exercise emergency stop and token revocation. |
 
+Documentation-only pushes to `main` skip the Windows packaging workflow because
+they cannot change the executable. Pull-request and main CI still run, tagged
+pushes always package, and an operator can start packaging manually with
+`workflow_dispatch`.
+
 ## Operational Signals
 
 - `/api/health` and `/api/ready` must report the expected version and production

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -281,6 +281,7 @@ describe('production readiness regressions', () => {
     const workflow = readFileSync(join(ROOT, '.github/workflows/build.yml'), 'utf8');
     const acceptance = JSON.parse(readFileSync(join(ROOT, 'release-acceptance.json'), 'utf8'));
     const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+    expect(workflow).toContain("paths-ignore:\n      - 'docs/**'\n      - '*.md'");
     expect(workflow).toContain('WINDOWS_SIGNING_PROVIDER must be unsigned, microsoft-store, pfx, azure-artifact-signing, or sslcom-esigner');
     expect(workflow).toContain("$env:WINDOWS_SIGNING_PROVIDER -eq 'unsigned'");
     expect(workflow).toContain('Tagged release is unsigned by owner-selected policy.');


### PR DESCRIPTION
## What changed

- skips the Windows packaging workflow when a `main` push changes only root Markdown or files under `docs/`
- leaves tagged pushes and manual `workflow_dispatch` packaging unchanged
- keeps normal CI unchanged for pull requests and `main`
- adds a production-readiness regression assertion and documents the trigger behavior

## Why

The documentation-only merge for PR #72 started a full Windows runner, production gate, Electron rebuild, packaging, and artifact upload even though the executable was unchanged. That run was cancelled during dependency installation. This filter avoids repeated release-runner cost without weakening validation or release behavior.

GitHub documents that path filters are not evaluated for tag pushes, so version tags still package.

## Validation

- workflow YAML parsed successfully
- focused production-readiness suite: 37 passed
- `npm run gate`: 74 files, 422 tests; all blocking gates passed
- traceability: 117/117 cited
- dependency audits: 0 vulnerabilities
- safety scan: 0 HIGH