### PR TITLE
Make workflow regression test line-ending neutral

### DIFF
--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -279,9 +279,10 @@ describe('production readiness regressions', () => {
 
   it('supports owner-selected unsigned releases while blocking unaccepted or mismatched tags', async () => {
     const workflow = readFileSync(join(ROOT, '.github/workflows/build.yml'), 'utf8');
+    const normalizedWorkflow = workflow.replace(/\r\n/g, '\n');
     const acceptance = JSON.parse(readFileSync(join(ROOT, 'release-acceptance.json'), 'utf8'));
     const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
-    expect(workflow).toContain("paths-ignore:\n      - 'docs/**'\n      - '*.md'");
+    expect(normalizedWorkflow).toContain("paths-ignore:\n      - 'docs/**'\n      - '*.md'");
     expect(workflow).toContain('WINDOWS_SIGNING_PROVIDER must be unsigned, microsoft-store, pfx, azure-artifact-signing, or sslcom-esigner');
     expect(workflow).toContain("$env:WINDOWS_SIGNING_PROVIDER -eq 'unsigned'");
     expect(workflow).toContain('Tagged release is unsigned by owner-selected policy.');


### PR DESCRIPTION
## What changed

Normalizes CRLF to LF before asserting the multiline `paths-ignore` block in the release-workflow regression test.

## Root cause

The test passed on Linux and the local checkout but failed in the protected-main Windows packaging workflow because Git checked `.github/workflows/build.yml` out with CRLF. The workflow itself parsed and triggered correctly; only the exact newline-sensitive assertion failed.

## Validation

- focused production-readiness suite: 37 passed
- explicit CRLF normalization simulation passed
- `git diff --check`
- failed Windows run `31760635571` showed 421/422 passing with this assertion as the sole failure