### PR TITLE
Fix Windows readiness test loading

### DIFF
--- a/tests/security/runtimeReadiness.test.ts
+++ b/tests/security/runtimeReadiness.test.ts
@@ -18,7 +18,7 @@ async function fixture() {
   for (let id = 1; id <= migrationCount; id += 1) insert.run(id);
   database.close();
 
-  const moduleUrl = `${pathToFileURL(join(ROOT, 'scripts/runtime-readiness.mjs')).href}?test=${Date.now()}`;
+  const moduleUrl = pathToFileURL(join(ROOT, 'scripts/runtime-readiness.mjs')).href;
   const readiness = await import(moduleUrl);
   const env = {
     NODE_ENV: 'production',


### PR DESCRIPTION
## What changed

Removed the unnecessary cache-busting query string from the readiness test's local `.mjs` import URL.

## Root cause

The Node 22 Windows runner rejected the query-suffixed local module URL with `SyntaxError: Invalid or unexpected token`. Linux CI and the production container passed, so the issue was isolated to the Windows test loader rather than the readiness implementation.

## Impact

The test still exercises a real temporary SQLite database, evidence storage, all readiness checks, and the HAI fail-closed assertion, but now uses a portable local module URL.

## Validation

- focused Windows test run: 2 files / 5 tests passed
- diff whitespace check passed
- prior exact-main CI passed; the Windows packaging workflow will be required to pass after this correction merges
