### PR TITLE
Exercise runtime readiness as a process

### DIFF
--- a/tests/security/runtimeReadiness.test.ts
+++ b/tests/security/runtimeReadiness.test.ts
@@ -1,13 +1,54 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
+import { spawn } from 'child_process';
 import { mkdtempSync, readdirSync, rmSync } from 'fs';
+import { createServer, type Server } from 'http';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { pathToFileURL } from 'url';
 
 const ROOT = join(__dirname, '../..');
 
-async function fixture() {
+async function startHealthServer(haiStatus: number) {
+  const server = createServer((request, response) => {
+    const bodies: Record<string, { status: number; body: object }> = {
+      '/api/live': { status: 200, body: { status: 'alive' } },
+      '/api/ready': { status: 200, body: { status: 'ready', dbReady: true } },
+      '/api/health': { status: 200, body: { status: 'healthy', dbReady: true, version: '1.3.0' } },
+      '/api/integrations/hai/health': {
+        status: haiStatus,
+        body: haiStatus === 401 ? { error: 'A valid LARO HAI bearer token is required' } : { status: 'healthy' },
+      },
+    };
+    const result = bodies[request.url || ''] ?? { status: 404, body: { error: 'Not found' } };
+    response.writeHead(result.status, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify(result.body));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Readiness test server did not bind to a TCP port.');
+  return { server, port: address.port };
+}
+
+function runReadiness(env: NodeJS.ProcessEnv) {
+  return new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, [join(ROOT, 'scripts/runtime-readiness.mjs')], {
+      cwd: ROOT,
+      env: { ...process.env, ...env },
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    child.once('error', reject);
+    child.once('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function fixture(haiStatus = 401) {
   const directory = mkdtempSync(join(tmpdir(), 'laro-runtime-readiness-'));
   const databasePath = join(directory, 'laro.sqlite');
   const storagePath = join(directory, 'uploads');
@@ -18,8 +59,7 @@ async function fixture() {
   for (let id = 1; id <= migrationCount; id += 1) insert.run(id);
   database.close();
 
-  const moduleUrl = pathToFileURL(join(ROOT, 'scripts/runtime-readiness.mjs')).href;
-  const readiness = await import(moduleUrl);
+  const healthServer = await startHealthServer(haiStatus);
   const env = {
     NODE_ENV: 'production',
     SERVER_ONLY: 'true',
@@ -27,55 +67,42 @@ async function fixture() {
     COOKIE_SECRET: 'c'.repeat(48),
     DATABASE_URL: databasePath,
     LOCAL_STORAGE_DIR: storagePath,
-    PORT: '3000',
+    PORT: String(healthServer.port),
   };
-  return { directory, env, readiness };
-}
-
-function healthyFetch(haiStatus = 401) {
-  return async (input: string | URL | Request) => {
-    const path = new URL(String(input)).pathname;
-    if (path === '/api/live') return Response.json({ status: 'alive' });
-    if (path === '/api/ready') return Response.json({ status: 'ready', dbReady: true });
-    if (path === '/api/health') return Response.json({ status: 'healthy', dbReady: true, version: '1.3.0' });
-    if (path === '/api/integrations/hai/health') {
-      return Response.json({ error: 'A valid LARO HAI bearer token is required' }, { status: haiStatus });
-    }
-    return Response.json({ error: 'Not found' }, { status: 404 });
-  };
+  return { directory, env, server: healthServer.server };
 }
 
 describe('production runtime readiness', () => {
   const directories: string[] = [];
-  afterEach(() => {
+  const servers: Server[] = [];
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    })));
     for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
   });
 
   it('verifies the lean API image contract without development tooling', async () => {
     const current = await fixture();
     directories.push(current.directory);
-    const report = await current.readiness.assessRuntimeReadiness({
-      env: current.env,
-      fetchImpl: healthyFetch(),
-    });
+    servers.push(current.server);
+    const result = await runReadiness(current.env);
 
-    expect(report.ok).toBe(true);
-    expect(report.checks.every((entry: { ok: boolean }) => entry.ok)).toBe(true);
-    expect(report.checks.find((entry: { name: string }) => entry.name === 'database migrations')?.detail)
-      .toMatch(/^\d+\/\d+ applied$/);
+    expect(result).toMatchObject({ code: 0, stderr: '' });
+    expect(result.stdout).toContain('Runtime readiness passed.');
+    expect(result.stdout).toMatch(/\[PASS\] database migrations: \d+\/\d+ applied/);
+    expect(result.stdout).toContain('[PASS] HAI authentication boundary: HTTP 401');
     expect(readdirSync(current.env.LOCAL_STORAGE_DIR)).toEqual([]);
   });
 
   it('fails when the HAI route stops enforcing bearer authentication', async () => {
-    const current = await fixture();
+    const current = await fixture(200);
     directories.push(current.directory);
-    const report = await current.readiness.assessRuntimeReadiness({
-      env: current.env,
-      fetchImpl: healthyFetch(200),
-    });
+    servers.push(current.server);
+    const result = await runReadiness(current.env);
 
-    expect(report.ok).toBe(false);
-    expect(report.checks.find((entry: { name: string }) => entry.name === 'HAI authentication boundary'))
-      .toMatchObject({ ok: false, detail: 'HTTP 200' });
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('[FAIL] HAI authentication boundary: HTTP 200; status=healthy');
+    expect(result.stderr).toContain('Runtime is not ready.');
   });
 });


### PR DESCRIPTION
## What changed

Replaced Vitest's in-process dynamic import of the runtime `.mjs` entrypoint with a black-box child-process test. The test now launches the exact production command against a real temporary SQLite database, evidence directory, and local health server.

## Root cause

The Windows Node 22 runner rejected Vitest's dynamic loading path for the `.mjs` runtime entrypoint with `SyntaxError: Invalid or unexpected token`. The production script itself runs successfully inside the deployed container; the failure was isolated to the test harness.

## Impact

Coverage is stronger and more portable:

- success is asserted through the real CLI exit code and output
- database migration parity and evidence storage still use real temporary resources
- the HAI fail-closed regression test now verifies the real process exits nonzero when the route returns HTTP 200

## Validation

- focused runtime tests: 2 files / 5 tests passed
- full production gate: 76 files / 428 tests passed
- server, main, and renderer typechecks passed
- lint passed
- dependency and runtime audits found zero vulnerabilities
- recovery drills passed
- traceability 117/117; zero runtime no-excuses findings; zero HIGH account-safety findings
