### PR TITLE
Harden keyboard navigation and reduced motion

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -11,6 +11,12 @@ Date: 2026-08-14
   and one-time-code autocomplete metadata.
 - Radix UI primitives provide keyboard and focus behavior for dialogs, popovers,
   dropdowns, tabs, and selects.
+- The authenticated dashboard mounts a localized skip link that moves focus to
+  the main region. Closed mobile navigation is removed from the focus order;
+  opening it moves focus inside, traps Tab/Shift+Tab, supports Escape, and
+  restores focus to the opener.
+- The renderer disables nonessential animation and transition duration when the
+  operating system requests reduced motion.
 - `server/accessibility.ts` provides contrast checks, keyboard activation,
   screen-reader announcements, focus trapping, and accessible-label helpers.
 
@@ -24,7 +30,10 @@ Date: 2026-08-14
 - `tests/browser/rendererAccessibility.spec.ts` runs axe-core against every
   supported static route at 1440x900 and 390x844. It also blocks unnamed visible
   controls, missing primary headings, horizontal overflow, page errors, failed
-  requests, and console errors. GitHub Actions runs this as the
+  requests, and console errors. Its interaction audit verifies desktop shell
+  focus order, skip-link behavior, mobile navigation focus containment and
+  restoration, account and notification overlay geometry, keyboard FAQ state,
+  and reduced-motion duration. GitHub Actions runs this as the
   `renderer-accessibility` job.
 - Vitest runs only maintained suite directories. A recursive release regression
   check rejects test files outside those directories so excluded or broken
@@ -49,6 +58,14 @@ consolidated Evidence workspace.
   controls while remaining inside the viewport.
 - The notification popover remained inside the mobile viewport and its trigger
   reported unread state through its accessible name.
+- Keyboard focus never entered the closed mobile sidebar. The opened sidebar
+  retained focus until Escape and then returned focus to the mobile trigger.
+- Account and notification overlays remained inside their viewport and returned
+  focus to their trigger when dismissed.
+- The localized skip link became visible on focus and transferred focus to the
+  main content region.
+- Reduced-motion emulation limited transition and animation duration to at most
+  one millisecond for the exercised interaction state.
 - No page error, console error, or console warning occurred during the sweep.
 - No serious or critical WCAG 2.0/2.1 A/AA axe-core violation remained. The
   audit found and fixed the global primary-button contrast token and required
@@ -60,6 +77,7 @@ from the visible-field check.
 ## Remaining scope
 
 - The route audit is not a complete WCAG conformance assessment.
-- A screen-reader session, complete keyboard focus-order review, and
-  reduced-motion review remain recommended before a public WCAG conformance
-  claim. LARO does not claim formal conformance.
+- A human screen-reader session, route-specific keyboard review of complex case
+  and evidence editors, and platform-normalized pixel baselines remain
+  recommended before a public WCAG conformance claim. LARO does not claim
+  formal conformance.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,10 @@ Current as of 2026-08-14.
 - Blocking accessibility coverage for all 15 mounted routes at desktop and
   mobile sizes, including axe, control naming, overflow, request, console, and
   page-error checks.
+- Blocking shared-shell keyboard coverage for localized skip navigation,
+  desktop focus order, mobile sidebar exclusion/trapping/Escape restoration,
+  overlay geometry and trigger restoration, keyboard FAQ state, and reduced
+  motion.
 - Removal of excluded legacy test files with broken imports or disconnected
   assertions; release coverage now lives only in explicitly maintained suites.
 
@@ -49,8 +53,9 @@ must not be represented as operational.
 1. Expand declared foreign keys after installed-data reconciliation; the
    production data-readiness gate now detects violations before migration.
 2. Complete renderer NL/EN string migration.
-3. Expand interaction-state visual regression and keyboard focus-order coverage
-   beyond the existing all-route axe and responsive browser gate.
+3. Add platform-normalized pixel baselines for high-risk interaction states and
+   extend focus-order coverage into complex route-specific case and evidence
+   editors; shared-shell keyboard behavior is now blocking.
 4. Normalize historical text-backed numeric fields through a reviewed migration.
 5. Continue dependency review while preserving the enforced renderer bundle budgets.
 

--- a/shared/i18n.ts
+++ b/shared/i18n.ts
@@ -30,6 +30,7 @@ export const messages = {
   "nav.analytics": { nl: "Analyse", en: "Analytics" },
   "nav.settings": { nl: "Instellingen", en: "Settings" },
   "nav.signOut": { nl: "Afmelden", en: "Sign out" },
+  "nav.skipToContent": { nl: "Ga naar de hoofdinhoud", en: "Skip to main content" },
   "nav.expandSidebar": { nl: "Zijbalk uitklappen", en: "Expand sidebar" },
   "nav.collapseSidebar": { nl: "Zijbalk inklappen", en: "Collapse sidebar" },
   "nav.accountMenu": { nl: "Accountmenu openen", en: "Open account menu" },

--- a/src/renderer/DashboardApp.tsx
+++ b/src/renderer/DashboardApp.tsx
@@ -11,6 +11,7 @@ import { WebSocketProvider } from "@/contexts/WebSocketContext";
 import { useI18n } from "@/contexts/I18nContext";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import SkipNavigation from "@/components/SkipNavigation";
 
 const Home = lazy(() => import("@/components/Home"));
 const Cases = lazy(() => import("@/components/Cases"));
@@ -56,41 +57,44 @@ export default function DashboardApp() {
   }
 
   return (
-    <WebSocketProvider>
-    <Router {...(fileProtocol ? { hook: useHashLocation } : {})}>
-    <Suspense fallback={<DashboardSkeleton />}>
-    <Switch>
-      <Route path="/" component={Home} />
-      <Route path="/cases" component={Cases} />
-      <Route path="/evidence" component={Evidence} />
-      <Route path="/lawyers/:id" component={LawyerProfile} />
-      <Route path="/lawyers" component={Lawyers} />
-      <Route path="/outreach" component={OutreachAnalytics} />
-      <Route path="/help" component={Help} />
+    <>
+      <SkipNavigation />
+      <WebSocketProvider>
+        <Router {...(fileProtocol ? { hook: useHashLocation } : {})}>
+          <Suspense fallback={<DashboardSkeleton />}>
+            <Switch>
+              <Route path="/" component={Home} />
+              <Route path="/cases" component={Cases} />
+              <Route path="/evidence" component={Evidence} />
+              <Route path="/lawyers/:id" component={LawyerProfile} />
+              <Route path="/lawyers" component={Lawyers} />
+              <Route path="/outreach" component={OutreachAnalytics} />
+              <Route path="/help" component={Help} />
 
-      <Route path="/settings" component={Settings} />
-      <Route path="/email-settings" component={Settings} />
-      <Route path="/email-preferences" component={Settings} />
-      <Route path="/privacy" component={Privacy} />
+              <Route path="/settings" component={Settings} />
+              <Route path="/email-settings" component={Settings} />
+              <Route path="/email-preferences" component={Settings} />
+              <Route path="/privacy" component={Privacy} />
 
-      <Route path="/admin" component={Admin} />
-      <Route path="/admin-analytics" component={Admin} />
+              <Route path="/admin" component={Admin} />
+              <Route path="/admin-analytics" component={Admin} />
 
-      <Route path="/messages" component={Messages} />
-      <Route path="/email" component={Messages} />
-      <Route path="/analytics">
-        <OutreachAnalytics />
-      </Route>
+              <Route path="/messages" component={Messages} />
+              <Route path="/email" component={Messages} />
+              <Route path="/analytics">
+                <OutreachAnalytics />
+              </Route>
 
-      <Route>
-        <div className="p-8 text-center text-muted-foreground">
-          <p className="font-medium text-foreground">{t("route.notFound")}</p>
-          <p className="mt-2 text-sm">{t("route.notFoundHint")}</p>
-        </div>
-      </Route>
-    </Switch>
-    </Suspense>
-    </Router>
-    </WebSocketProvider>
+              <Route>
+                <div className="p-8 text-center text-muted-foreground">
+                  <p className="font-medium text-foreground">{t("route.notFound")}</p>
+                  <p className="mt-2 text-sm">{t("route.notFoundHint")}</p>
+                </div>
+              </Route>
+            </Switch>
+          </Suspense>
+        </Router>
+      </WebSocketProvider>
+    </>
   );
 }

--- a/src/renderer/components/DashboardLayout.tsx
+++ b/src/renderer/components/DashboardLayout.tsx
@@ -229,7 +229,7 @@ function DashboardLayoutContent({
                     type="button"
                     onClick={toggleSidebar}
                     aria-label={t("nav.expandSidebar")}
-                    className="absolute inset-0 flex items-center justify-center rounded-lg bg-sidebar-accent/80 opacity-0 transition-opacity group-hover:opacity-100 focus:outline-none"
+                    className="absolute inset-0 flex items-center justify-center rounded-lg bg-sidebar-accent/80 opacity-0 transition-opacity group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
                   >
                     <PanelLeft className="h-4 w-4 text-sidebar-foreground" />
                   </button>
@@ -250,7 +250,7 @@ function DashboardLayoutContent({
                     type="button"
                     onClick={toggleSidebar}
                     aria-label={t("nav.collapseSidebar")}
-                    className="ml-auto flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus:outline-none"
+                    className="ml-auto flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
                   >
                     <PanelLeft className="h-4 w-4" />
                   </button>
@@ -362,7 +362,7 @@ function DashboardLayoutContent({
             </div>
           </div>
         )}
-        <main id="main-content" className="min-w-0 flex-1 bg-black p-3 sm:p-6 md:p-8">
+        <main id="main-content" tabIndex={-1} className="min-w-0 flex-1 bg-black p-3 outline-none sm:p-6 md:p-8">
           {children}
           <LegalAdviceNotice />
         </main>

--- a/src/renderer/components/SkipNavigation.tsx
+++ b/src/renderer/components/SkipNavigation.tsx
@@ -1,3 +1,5 @@
+import { useI18n } from "@/contexts/I18nContext";
+
 /**
  * Skip Navigation Component
  * 
@@ -6,13 +8,15 @@
  */
 
 export default function SkipNavigation() {
+  const { t } = useI18n();
+
   return (
     <>
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-orange-500 focus:text-white focus:rounded-lg focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-600 focus:ring-offset-2"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-orange-500 focus:px-4 focus:py-2 focus:text-slate-950 focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-300 focus:ring-offset-2 focus:ring-offset-background"
       >
-        Skip to main content
+        {t("nav.skipToContent")}
       </a>
       {/* ARIA live region for screen reader announcements */}
       <div

--- a/src/renderer/components/ui/sidebar.tsx
+++ b/src/renderer/components/ui/sidebar.tsx
@@ -176,6 +176,66 @@ function Sidebar({
   disableTransition?: boolean;
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+  const mobileSidebarRef = React.useRef<HTMLElement>(null);
+  const restoreFocusRef = React.useRef<HTMLElement | null>(null);
+
+  React.useLayoutEffect(() => {
+    const sidebar = mobileSidebarRef.current;
+    if (!sidebar) return;
+    sidebar.inert = !openMobile;
+    if (!isMobile || !openMobile) return;
+
+    restoreFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const focusableSelector = [
+      "a[href]",
+      "button:not([disabled])",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "[tabindex]:not([tabindex='-1'])",
+    ].join(",");
+    const getFocusable = () => Array.from(
+      sidebar.querySelectorAll<HTMLElement>(focusableSelector),
+    ).filter((element) => !element.hasAttribute("hidden") && element.getClientRects().length > 0);
+
+    sidebar.querySelector<HTMLElement>(focusableSelector)?.focus({ preventScroll: true });
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpenMobile(false);
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        event.preventDefault();
+        sidebar.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      const restoreTarget = restoreFocusRef.current;
+      if (restoreTarget?.isConnected) {
+        restoreTarget.focus();
+      }
+    };
+  }, [isMobile, openMobile, setOpenMobile]);
 
   if (collapsible === "none") {
     return (
@@ -203,26 +263,32 @@ function Sidebar({
           <button
             type="button"
             aria-label="Close menu"
+            aria-hidden="true"
+            tabIndex={-1}
             className="fixed inset-0 z-40 bg-black/50 md:hidden"
             onClick={() => setOpenMobile(false)}
           />
         ) : null}
         <aside
+          ref={mobileSidebarRef}
+          id="laro-mobile-sidebar"
           data-slot="sidebar"
           data-state={openMobile ? "expanded" : "collapsed"}
           data-collapsible={collapsible}
           data-variant={variant}
           data-side={side}
+          aria-hidden={!openMobile}
+          tabIndex={-1}
           className={cn(
             "fixed inset-y-0 z-50 flex h-svh flex-col border-r border-sidebar-accent/25 bg-sidebar text-sidebar-foreground md:hidden",
             side === "left" ? "left-0" : "right-0",
             "w-[min(100vw,var(--sidebar-width))]",
             transitionClass,
             openMobile
-              ? "translate-x-0"
+              ? "visible translate-x-0"
               : side === "left"
-                ? "-translate-x-full"
-                : "translate-x-full",
+                ? "invisible -translate-x-full pointer-events-none"
+                : "invisible translate-x-full pointer-events-none",
             className
           )}
           {...props}
@@ -328,18 +394,37 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 function SidebarTrigger({
   className,
   onClick,
+  onKeyUp,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, isMobile, openMobile } = useSidebar();
+  const focusMobileSidebar = React.useCallback(() => {
+    const sidebar = document.getElementById("laro-mobile-sidebar");
+    if (sidebar?.getAttribute("aria-hidden") === "false") {
+      sidebar.querySelector<HTMLElement>("button:not([disabled])")?.focus({ preventScroll: true });
+    }
+  }, []);
   return (
     <Button
       data-sidebar="trigger"
+      aria-controls={isMobile ? "laro-mobile-sidebar" : undefined}
+      aria-expanded={isMobile ? openMobile : undefined}
       variant="ghost"
       size="icon"
       className={cn("h-9 w-9", className)}
       onClick={(e) => {
+        const openingMobileSidebar = isMobile && !openMobile;
         toggleSidebar();
+        if (openingMobileSidebar) {
+          window.setTimeout(focusMobileSidebar, 50);
+        }
         onClick?.(e);
+      }}
+      onKeyUp={(event) => {
+        if (isMobile && openMobile && (event.key === "Enter" || event.key === " ")) {
+          focusMobileSidebar();
+        }
+        onKeyUp?.(event);
       }}
       {...props}
     >

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -49,3 +49,14 @@ code {
   width: 100%;
   height: 100vh;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/tests/browser/rendererAccessibility.spec.ts
+++ b/tests/browser/rendererAccessibility.spec.ts
@@ -1,5 +1,5 @@
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 import Database from "better-sqlite3";
 import { resolve } from "node:path";
 
@@ -50,6 +50,55 @@ function formatViolations(
       return `${viewport} ${route}: ${violation.id} (${violation.impact}) ${violation.help}; ${targets}`;
     })
     .join("\n");
+}
+
+async function resetKeyboardFocus(page: Page) {
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+  });
+}
+
+async function expectVisibleKeyboardFocus(page: Page, locator: Locator) {
+  await expect(locator).toBeFocused();
+  const focusState = await locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const style = window.getComputedStyle(element);
+    return {
+      width: rect.width,
+      height: rect.height,
+      insideViewport:
+        rect.left >= -1
+        && rect.top >= -1
+        && rect.right <= window.innerWidth + 1
+        && rect.bottom <= window.innerHeight + 1,
+      hasIndicator:
+        Number.parseFloat(style.outlineWidth) > 0
+        || (style.boxShadow !== "none" && style.boxShadow.trim() !== ""),
+    };
+  });
+  expect(focusState.width).toBeGreaterThan(0);
+  expect(focusState.height).toBeGreaterThan(0);
+  expect(focusState.insideViewport).toBe(true);
+  expect(focusState.hasIndicator).toBe(true);
+}
+
+async function expectInsideViewport(locator: Locator) {
+  const geometry = await locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      width: rect.width,
+      height: rect.height,
+      insideViewport:
+        rect.left >= -1
+        && rect.top >= -1
+        && rect.right <= window.innerWidth + 1
+        && rect.bottom <= window.innerHeight + 1,
+    };
+  });
+  expect(geometry.width).toBeGreaterThan(0);
+  expect(geometry.height).toBeGreaterThan(0);
+  expect(geometry.insideViewport).toBe(true);
 }
 
 function analysisResult(options: { party: string; date: string; title: string; text: string }) {
@@ -159,6 +208,106 @@ test("language selection changes the mounted shell and persists across reloads",
   await page.getByRole("group", { name: "Taal" }).getByRole("button", { name: "en", exact: true }).click();
   await expect(page.locator("html")).toHaveAttribute("lang", "en");
   await expect(page.getByText("My Cases", { exact: true })).toBeVisible();
+});
+
+test("keyboard navigation exposes the skip link, traps the mobile menu, and keeps interaction states visible", async ({ page }, testInfo) => {
+  await createAccount(page);
+
+  await page.setViewportSize(VIEWPORTS[0]);
+  await page.goto("/help", { waitUntil: "networkidle" });
+  await resetKeyboardFocus(page);
+
+  const skipLink = page.getByRole("link", { name: "Skip to main content" });
+  await page.keyboard.press("Tab");
+  await expectVisibleKeyboardFocus(page, skipLink);
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#main-content")).toBeFocused();
+
+  await page.goto("/help", { waitUntil: "networkidle" });
+  await resetKeyboardFocus(page);
+  const desktopFocusOrder = [
+    page.getByRole("link", { name: "Skip to main content" }),
+    page.getByRole("button", { name: "Collapse sidebar" }),
+    page.getByRole("button", { name: "Home", exact: true }),
+    page.getByRole("button", { name: "My Cases", exact: true }),
+    page.getByRole("button", { name: "Evidence", exact: true }),
+    page.getByRole("button", { name: "Outreach", exact: true }),
+    page.getByRole("button", { name: "Help & Resources", exact: true }),
+    page.getByRole("button", { name: "Open account menu" }),
+  ];
+  for (const control of desktopFocusOrder) {
+    await page.keyboard.press("Tab");
+    await expectVisibleKeyboardFocus(page, control);
+  }
+
+  const accountMenuTrigger = desktopFocusOrder[desktopFocusOrder.length - 1];
+  await page.keyboard.press("Enter");
+  const accountMenu = page.locator('[data-slot="dropdown-menu-content"]');
+  await expect(accountMenu).toBeVisible();
+  await expectInsideViewport(accountMenu);
+  await expect(accountMenu.locator(":focus")).toHaveCount(1);
+  await page.keyboard.press("Escape");
+  await expect(accountMenuTrigger).toBeFocused();
+
+  await page.setViewportSize(VIEWPORTS[1]);
+  await page.goto("/help", { waitUntil: "networkidle" });
+  await resetKeyboardFocus(page);
+  await page.keyboard.press("Tab");
+  await expectVisibleKeyboardFocus(page, skipLink);
+  await page.keyboard.press("Tab");
+  const mobileMenuTrigger = page.getByRole("button", { name: "Toggle sidebar" });
+  await expectVisibleKeyboardFocus(page, mobileMenuTrigger);
+  await page.keyboard.press("Enter");
+  await expect(mobileMenuTrigger).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("#laro-mobile-sidebar")).toHaveAttribute("aria-hidden", "false");
+
+  const mobileMenuClose = page.getByRole("button", { name: "Collapse sidebar" });
+  await expectVisibleKeyboardFocus(page, mobileMenuClose);
+  await page.keyboard.press("Shift+Tab");
+  await expectVisibleKeyboardFocus(page, page.getByRole("button", { name: "Open account menu" }));
+  await page.keyboard.press("Escape");
+  await expect(mobileMenuTrigger).toBeFocused();
+
+  const notificationTrigger = page.getByRole("button", { name: /Open notifications/ });
+  await notificationTrigger.focus();
+  await expectVisibleKeyboardFocus(page, notificationTrigger);
+  await page.keyboard.press("Enter");
+  const notificationPopover = page.locator('[data-slot="popover-content"]');
+  await expect(notificationPopover).toBeVisible();
+  await expect(notificationPopover.getByText("Notifications", { exact: true })).toBeVisible();
+  await expectInsideViewport(notificationPopover);
+  await page.screenshot({ path: testInfo.outputPath("mobile-notification-keyboard.png"), fullPage: false });
+  await page.keyboard.press("Escape");
+  await expect(notificationTrigger).toBeFocused();
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.setViewportSize(VIEWPORTS[0]);
+  await page.goto("/help", { waitUntil: "networkidle" });
+  const firstFaq = page.getByRole("button", { name: "How does LARO find lawyers for my case?" });
+  await firstFaq.focus();
+  await expectVisibleKeyboardFocus(page, firstFaq);
+  await page.keyboard.press("Space");
+  await expect(firstFaq).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("#faq-answer-0")).toBeVisible();
+  const motion = await firstFaq.evaluate((element) => {
+    const parseDurations = (value: string) => value.split(",").map((duration) => {
+      const normalized = duration.trim();
+      return normalized.endsWith("ms")
+        ? Number.parseFloat(normalized)
+        : Number.parseFloat(normalized) * 1_000;
+    });
+    const style = window.getComputedStyle(element);
+    return {
+      reduced: window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      maximumDurationMs: Math.max(
+        ...parseDurations(style.animationDuration),
+        ...parseDurations(style.transitionDuration),
+      ),
+    };
+  });
+  expect(motion.reduced).toBe(true);
+  expect(motion.maximumDurationMs).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath("desktop-faq-keyboard.png"), fullPage: false });
 });
 
 test("Settings presents an owned Flask migration without responsive overflow", async ({ page }) => {


### PR DESCRIPTION
## What changed

- Mount the localized skip-navigation control and make the main region a reliable focus target.
- Remove the closed mobile sidebar from keyboard traversal.
- Add deterministic mobile sidebar focus entry, Tab/Shift+Tab containment, Escape dismissal, focus restoration, and expanded/controls semantics.
- Add visible focus treatment for raw sidebar controls.
- Respect the operating system reduced-motion preference.
- Extend the blocking Playwright audit with desktop/mobile focus order, overlay geometry, keyboard state, and reduced-motion checks.
- Update accessibility and roadmap evidence to distinguish automated coverage from remaining human and pixel-baseline work.

## Root cause

The skip-link component existed but was never mounted. The off-canvas mobile sidebar remained focusable while visually closed and had no complete focus lifecycle. Keyboard button activation also required focus transfer after the browser's activation sequence rather than only during React layout.

## User impact

Keyboard users can enter the main content immediately, no longer tab through hidden mobile navigation, and retain a predictable focus location when opening or closing menus. Reduced-motion users avoid nonessential animation duration.

## Validation

- `npm run gate`: passed, including 77 test files / 435 tests, bundle budgets, zero dependency vulnerabilities, traceability, safety scans, and both recovery drills.
- `npm run test:a11y:browser`: 5/5 passed across 15 routes at desktop/mobile plus interaction workflows.
- `python -m pip check`: passed.
- `python -m unittest discover -v -p "test_*.py"`: 222 passed.
- Renderer typecheck and focused lint: passed.

## Browser note

The in-app Browser timed out attaching a new local webview before navigation. The repository's blocking Playwright Chromium workflow was used as the established fallback and passed from a fresh test server/database.