### PR TITLE
Package database readiness command

### DIFF
--- a/docs/OPERATOR_READINESS.md
+++ b/docs/OPERATOR_READINESS.md
@@ -23,7 +23,11 @@ Production mode also runs the `db:readiness` checks against the configured
 database. It blocks on SQLite integrity errors, declared foreign-key violations,
 missing legacy relationship guards, failed invariants, reconciliation findings,
 duplicate emails, or exact known demo/test account markers. The report contains
-counts only and does not print case or user data.
+counts only and does not print case or user data. The same command is packaged
+as a compiled operation in the API-only production image; it does not require
+development dependencies such as `tsx`. In a source checkout, the command
+prefers the current TypeScript source and first restores the Node ABI for
+`better-sqlite3`, including after an Electron build or package operation.
 
 ## Release Checklist
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "db:backup": "node scripts/run-built-operation.mjs backup",
     "db:restore": "node scripts/run-built-operation.mjs backup --restore",
     "db:validate": "node scripts/run-built-operation.mjs backup --validate",
-    "db:readiness": "npm run rebuild:node && tsx scripts/data-readiness.ts",
+    "db:readiness": "node scripts/run-built-operation.mjs data-readiness",
     "recovery:drill": "tsx scripts/recovery-drill.ts",
     "flask:backup": "python scripts/flask_recovery.py backup",
     "flask:validate": "python scripts/flask_recovery.py validate",

--- a/scripts/run-built-operation.mjs
+++ b/scripts/run-built-operation.mjs
@@ -9,6 +9,12 @@ const operations = {
     built: 'dist/server/scripts/backup.js',
     source: 'scripts/backup.ts',
   },
+  'data-readiness': {
+    built: 'dist/server/scripts/data-readiness.js',
+    source: 'scripts/data-readiness.ts',
+    preferSourceWhenAvailable: true,
+    rebuildNodeForSource: true,
+  },
   'acceptance:providers': {
     built: 'dist/server/server/liveProviderAcceptance.js',
     source: 'server/liveProviderAcceptance.ts',
@@ -32,19 +38,41 @@ if (!operation) {
 
 const builtPath = resolve(operation.built);
 const sourcePath = resolve(operation.source);
+let tsxCli;
+try {
+  tsxCli = require.resolve('tsx/cli');
+} catch {
+  tsxCli = undefined;
+}
+const useSource = Boolean(operation.preferSourceWhenAvailable && tsxCli);
 let childArguments;
-if (existsSync(builtPath)) {
+if (!useSource && existsSync(builtPath)) {
   childArguments = [builtPath, ...process.argv.slice(3)];
 } else {
-  let tsxCli;
-  try {
-    tsxCli = require.resolve('tsx/cli');
-  } catch {
+  if (!tsxCli) {
     console.error(
       `The compiled runtime operation is missing: ${operation.built}. ` +
-      'Build the server before running this command in a production installation.',
+        'Build the server before running this command in a production installation.',
     );
     process.exit(1);
+  }
+  if (operation.rebuildNodeForSource) {
+    const npmCli = process.env.npm_execpath;
+    if (!npmCli) {
+      console.error('Run this maintenance operation through its npm script so the Node native module can be rebuilt.');
+      process.exit(1);
+    }
+    const rebuild = spawnSync(process.execPath, [npmCli, 'run', 'rebuild:node'], {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+    if (rebuild.error) {
+      console.error(rebuild.error.message);
+      process.exit(1);
+    }
+    if (rebuild.status !== 0) process.exit(rebuild.status ?? 1);
   }
   childArguments = [tsxCli, sourcePath, ...process.argv.slice(3)];
 }

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -524,7 +524,7 @@ describe('production readiness regressions', () => {
     const readiness = readFileSync(join(ROOT, 'scripts/operator-readiness.mjs'), 'utf8');
     expect(pkg.scripts.readiness).toContain('npm run rebuild:node');
     expect(pkg.scripts['readiness:production']).toContain('npm run rebuild:node');
-    expect(pkg.scripts['db:readiness']).toContain('scripts/data-readiness.ts');
+    expect(pkg.scripts['db:readiness']).toContain('run-built-operation.mjs data-readiness');
     expect(readiness).toContain("name: 'target database readiness'");
     expect(readiness).toContain("'scripts/data-readiness.ts'");
     expect(readiness).toContain('[result.stdout, result.stderr]');

--- a/tests/security/runtimeOperations.test.ts
+++ b/tests/security/runtimeOperations.test.ts
@@ -5,17 +5,23 @@ import { describe, expect, it } from 'vitest';
 const ROOT = path.resolve(__dirname, '../..');
 
 describe('production runtime operations', () => {
-  it('runs backup and live acceptance through compiled fallbacks', () => {
+  it('runs maintenance and live acceptance through compiled fallbacks', () => {
     const pkg = JSON.parse(readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
     const runner = readFileSync(path.join(ROOT, 'scripts/run-built-operation.mjs'), 'utf8');
     const serverConfig = JSON.parse(readFileSync(path.join(ROOT, 'tsconfig.server.json'), 'utf8'));
     const dockerfile = readFileSync(path.join(ROOT, 'Dockerfile'), 'utf8');
 
     expect(pkg.scripts['db:backup']).toContain('run-built-operation.mjs backup');
+    expect(pkg.scripts['db:readiness']).toContain('run-built-operation.mjs data-readiness');
     expect(pkg.scripts['acceptance:providers']).toContain('run-built-operation.mjs acceptance:providers');
     expect(runner).toContain('dist/server/scripts/backup.js');
+    expect(runner).toContain('dist/server/scripts/data-readiness.js');
+    expect(runner).toContain('preferSourceWhenAvailable: true');
+    expect(runner).toContain('rebuildNodeForSource: true');
+    expect(runner).toContain("[npmCli, 'run', 'rebuild:node']");
     expect(runner).toContain('dist/server/server/liveProviderAcceptance.js');
     expect(serverConfig.include).toContain('scripts/backup.ts');
+    expect(serverConfig.include).toContain('scripts/data-readiness.ts');
     expect(dockerfile).toContain('COPY scripts/run-built-operation.mjs ./scripts/run-built-operation.mjs');
   });
 

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -12,6 +12,7 @@
     "server/**/*",
     "shared/**/*",
     "scripts/backup.ts",
-    "scripts/backupArguments.ts"
+    "scripts/backupArguments.ts",
+    "scripts/data-readiness.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- compile the target database-readiness operator into the server bundle
- route `npm run db:readiness` through the existing source/compiled operation launcher
- make the same command work in pruned API-only production containers without `tsx`
- add packaging contract tests and update operator documentation

## Verification
- focused security/packaging suite: 42 passed
- compiled production-style `npm run db:readiness`: passed with 28/28 fields and 8/8 constraints
- `npm.cmd run gate`: 77 files, 438 tests; all blocking gates passed
- dependency audits: 0 vulnerabilities