### PR TITLE
Query exact Drive evidence without recursive scans

### DIFF
--- a/docs/NO_EXCUSES_SEARCH.md
+++ b/docs/NO_EXCUSES_SEARCH.md
@@ -37,12 +37,13 @@ Descriptive words (mock/stub/placeholder/fake) needing human judgement. Triage o
 | `server/_core/env.ts` | 101 | `* in production and the secrets are still the shipped placeholders (or empty),` |
 | `server/_core/env.ts` | 133 | `* to the insecure placeholder. Returns a list of non-fatal warnings (e.g.` |
 
-## Markers in tests / scripts / renderer (166) — reported, not failing
+## Markers in tests / scripts / renderer (176) — reported, not failing
 
 These are informational and do not identify unsupported runtime behavior by themselves; test/script occurrences are usually the words "mock"/"fake" used descriptively.
 
 | File | Marker count |
 |---|---|
+| `tests/backend/googleDriveAccountSelection.test.ts` | 15 |
 | `scripts/no-excuses-scan.mjs` | 14 |
 | `tests/backend/multiProviderLLM.test.ts` | 14 |
 | `src/renderer/components/SmartSearchFilters.tsx` | 7 |
@@ -51,7 +52,6 @@ These are informational and do not identify unsupported runtime behavior by them
 | `tests/backend/realSend.test.ts` | 6 |
 | `src/renderer/components/AuthPage.tsx` | 5 |
 | `src/renderer/components/EvidenceFilters.tsx` | 5 |
-| `tests/backend/googleDriveAccountSelection.test.ts` | 5 |
 | `tests/backend/novaDirectory.test.ts` | 5 |
 | `tests/security/productionReadiness.test.ts` | 5 |
 | `src/renderer/components/EvidenceSearch.tsx` | 4 |

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -111,8 +111,9 @@ npm.cmd run acceptance:google-drive-evidence-live -- `
   --run-id <stable-drive-acceptance-run-id>
 ```
 
-`--drive-folder-id` is optional and defaults to `root`; the scan is recursive.
-In the API container, invoke
+`--drive-folder-id` is accepted for command compatibility, but exact-name
+acceptance uses an account-wide paginated Drive query and does not walk the
+folder tree. In the API container, invoke
 `/app/dist/server/server/liveGoogleDriveEvidenceAcceptance.js` with the same
 arguments. Exact-name selection is checked before any matching file is
 downloaded, and the operation fails unless exactly one Drive file is found. It

--- a/server/autoCollectionService.ts
+++ b/server/autoCollectionService.ts
@@ -14,10 +14,14 @@ import {
 } from './schema';
 import { v4 as uuidv4 } from 'uuid';
 import { google } from 'googleapis';
-import { downloadAndUploadGoogleDriveFile, getGoogleDriveFileMetadata } from './googleDriveService';
+import {
+  downloadAndUploadGoogleDriveFile,
+  findGoogleDriveFilesByExactName,
+  getAllFilesInFolder,
+  getGoogleDriveFileMetadata,
+} from './googleDriveService';
 import { decryptToken, encryptToken, refreshGmailToken } from './emailOAuth';
 import { searchGmailEmails, getGmailMessage, getGmailAttachment } from './gmailService';
-import { getAllFilesInFolder } from './googleDriveService';
 import { storagePut } from './storage';
 import { createEvidenceFile } from './evidence';
 import { analyzeStoredEvidence } from './documentAnalysisService';
@@ -997,13 +1001,17 @@ async function pullFromDrive(
   const cred = await getFreshGmailAccessToken(userId, accountId);
   if (!cred) return { files: 0 };
 
-  const folders = folderIds.length > 0 ? folderIds : ['root'];
+  const normalizedExactFileName = exactFileName?.trim().toLowerCase();
+  const folders = normalizedExactFileName
+    ? ['exact-name-query']
+    : folderIds.length > 0 ? folderIds : ['root'];
   let downloaded = 0;
 
   for (const folderId of folders) {
     try {
-      const files = await getAllFilesInFolder(userId, folderId, true, cred.accountId);
-      const normalizedExactFileName = exactFileName?.trim().toLowerCase();
+      const files = normalizedExactFileName
+        ? await findGoogleDriveFilesByExactName(userId, exactFileName!, cred.accountId)
+        : await getAllFilesInFolder(userId, folderId, true, cred.accountId);
       const candidates = files.filter((file) => {
         if (!file.name || !file.id) return false;
         if (normalizedExactFileName) {

--- a/server/googleDriveService.ts
+++ b/server/googleDriveService.ts
@@ -214,6 +214,33 @@ export async function getAllFilesInFolder(
   return allFiles;
 }
 
+function escapeDriveQueryLiteral(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+/** Find exact filename matches across the selected account without walking folders. */
+export async function findGoogleDriveFilesByExactName(
+  userId: string,
+  exactFileName: string,
+  accountId?: string,
+): Promise<Array<{ id: string; name: string; mimeType?: string | null; size?: string | null; webViewLink?: string | null; modifiedTime?: string | null }>> {
+  const name = exactFileName.trim();
+  if (!name) return [];
+  const drive = await getDriveClient(userId, accountId);
+  const files: Array<{ id: string; name: string; mimeType?: string | null; size?: string | null; webViewLink?: string | null; modifiedTime?: string | null }> = [];
+  let pageToken: string | undefined;
+  do {
+    const response = await drive.files.list({
+      q: `name = '${escapeDriveQueryLiteral(name)}' and trashed = false and mimeType != 'application/vnd.google-apps.folder'`,
+      fields: 'nextPageToken, files(id, name, mimeType, size, webViewLink, modifiedTime)',
+      pageToken,
+    });
+    files.push(...((response.data.files || []) as typeof files));
+    pageToken = response.data.nextPageToken || undefined;
+  } while (pageToken);
+  return files.filter((file) => file.name?.trim().toLowerCase() === name.toLowerCase());
+}
+
 /**
  * Search files in Google Drive by query
  */

--- a/tests/backend/googleDriveAccountSelection.test.ts
+++ b/tests/backend/googleDriveAccountSelection.test.ts
@@ -136,6 +136,33 @@ suite("Google Drive account selection", () => {
     expect(googleMocks.listRequests[1]).toMatchObject({ pageToken: "drive-page-two" });
   });
 
+  it("finds exact Drive names globally across every result page", async () => {
+    googleMocks.listRequests.length = 0;
+    googleMocks.listResponses.push(
+      {
+        data: {
+          files: [{ id: "exact-page-one", name: "Court's file.pdf", mimeType: "application/pdf" }],
+          nextPageToken: "exact-page-two",
+        },
+      },
+      {
+        data: {
+          files: [{ id: "exact-page-two", name: "Court's file.pdf", mimeType: "application/pdf" }],
+        },
+      },
+    );
+    const { findGoogleDriveFilesByExactName } = await import("../../server/googleDriveService");
+    const files = await findGoogleDriveFilesByExactName(
+      userId,
+      "Court's file.pdf",
+      "GOOGLE_DRIVE_SECOND",
+    );
+
+    expect(files.map((file) => file.id)).toEqual(["exact-page-one", "exact-page-two"]);
+    expect(googleMocks.listRequests[0].q).toContain("name = 'Court\\'s file.pdf'");
+    expect(googleMocks.listRequests[1]).toMatchObject({ pageToken: "exact-page-two" });
+  });
+
   it("persists the selected Drive account and folders with auto-collection settings", async () => {
     const caller = app.makeCaller({ id: userId, role: "user" });
     await expect(caller.autoCollection.upsertSettings({


### PR DESCRIPTION
## What changed

- add an account-wide exact-name Google Drive query with full pagination and escaped query literals
- route explicit exact-file evidence pulls through that query instead of recursively walking the complete folder tree
- preserve the existing folder-recursive behavior for ordinary keyword evidence collection
- document the optimized acceptance behavior and add pagination/query regression coverage

## Root cause

The first real target run proved that a complete recursive walk can be operationally too slow on a large Drive. It was correct but wasteful because the acceptance already has an exact filename and only needs to prove global uniqueness.

## Impact

Drive acceptance now checks every exact-name result page globally, refuses zero or multiple matches, and downloads only the single accepted file. It avoids a second full tree traversal while retaining the same provenance, analysis, hash, source-open, receipt, and cleanup requirements.

## Validation

- full stabilization gate passed
- 78 test files and 442 tests passed
- all typechecks, lint, dependency audits, safety scans, bundle budgets, traceability, and recovery drills passed
- focused Drive account, pagination, exact-query, keyword-pull, and live-acceptance tests passed