### PR TITLE
Require proven Google Drive document intake

### DIFF
--- a/docs/ACCEPTANCE_TESTS.md
+++ b/docs/ACCEPTANCE_TESTS.md
@@ -38,12 +38,11 @@ temporary SQLite databases; they do not contact external people or accounts.
 | ID | Criterion | Required evidence | Current state |
 | --- | --- | --- | --- |
 | M1 | Live outreach delivery | Approved test recipient receives one message; duplicate send produces no second message | Passed 2026-08-14: one controlled inbox receipt, audit record, and duplicate block |
-| M2 | Gmail/Drive intake | Target OAuth client connects, pull completes, and imported records retain provenance | Partial: Gmail import/provenance and Drive root connectivity passed; representative Drive-file import remains pending |
+| M2 | Gmail/Drive intake | Target OAuth client connects, pull completes, and imported records retain provenance | Passed 2026-08-14: Gmail and Drive imports, analysis, provenance, hash verification, and source reopening passed |
 | M3 | Optional trusted public Windows release | When public distribution is selected: a Store-signed package or version-matched portable release with valid Authenticode signature, approved icon, and matching SHA-256 checksum | Out of scope for selected unsigned internal distribution |
 
-M1 requires organization-controlled credentials and was recorded for this target
-environment rather than replaced by local test doubles. M2 is not complete until
-a representative Drive file is imported and its provenance is verified. Any
-future deployment target must repeat both criteria.
+M1 and M2 require organization-controlled credentials and were recorded for this
+target environment rather than replaced by local test doubles. Any future
+deployment target must repeat both criteria.
 M3 is intentionally out of scope for the current unsigned internal distribution
 path and becomes required only if trusted public Windows distribution is enabled.

--- a/docs/CRITICAL_PATH.md
+++ b/docs/CRITICAL_PATH.md
@@ -48,7 +48,8 @@ Repository tests use injected delivery and Google boundaries and cannot by
 themselves prove a target account. The selected production scope completed its
 separate owner-controlled acceptance on 2026-08-14: Google consent, Gmail/Drive
 root reads, persisted Gmail evidence/source verification, and revocation passed;
-a representative Drive-file import remains pending. Outbound SMTP delivered
+a representative Drive-file import, analysis, provenance, hash verification,
+and source reopening passed. Outbound SMTP delivered
 once, retained its audit record, and blocked duplicate dispatch. Future
 credentials or deployment targets must repeat those checks rather than
 inheriting this approval.

--- a/docs/FINAL_VERIFICATION_REPORT.md
+++ b/docs/FINAL_VERIFICATION_REPORT.md
@@ -247,7 +247,7 @@ development renderer path from the launching shell.
 |---|---|---|
 | Trusted public Windows distribution | Deliberately out of scope | Configure Store or certificate signing only if platform publisher trust becomes a requirement; unsigned tagged delivery remains supported with a checksum and warning |
 | Public branding | Approved on 2026-07-21 | Owner-approved LARO timeline mark is stored in `build/icon.png` / `public/laro-logo.png`; release acceptance binds both files to SHA-256 `134ca32789b6dd24f0c39d461f0c405f1e1156475dceb0fa4e525373ab200a0f` |
-| Live providers | Approved on 2026-08-14 for the recorded checks | Google credentials, consent, Gmail import, Drive root read, Gmail evidence/source opening, and revocation passed; a representative Drive-file import remains pending; outbound approved delivery, receipt, audit, and duplicate blocking passed |
+| Live providers | Approved on 2026-08-14 for the recorded checks | Google credentials, consent, Gmail and Drive imports, analysis, provenance, source opening with matching hashes, and revocation passed; outbound approved delivery, receipt, audit, and duplicate blocking passed |
 | Exact-main local Windows launch | Awaiting explicit owner authorization | Launch downloaded artifact `9220496086` on this Windows 11 host and confirm healthy startup; checksum, ABI, packaging, and single-instance behavior already pass in Actions |
 
 These external states are represented in `release-acceptance.json`. Normal

--- a/docs/MANUAL_VERIFICATION.md
+++ b/docs/MANUAL_VERIFICATION.md
@@ -27,9 +27,9 @@ snapshot; exact release evidence is maintained in
 - A complete manifest-bound target backup validates with 55 tables, the current
   standalone secret compatibility tag, complete local evidence coverage, and no
   untracked SQLite sidecars.
-- Google target acceptance verified consent, Gmail and Drive root reads, one
-  persisted Gmail source, source reopening with a matching hash, and disconnect
-  revocation. A representative Drive-file import remains pending.
+- Google target acceptance verified consent, Gmail and Drive root reads,
+  representative Gmail and Drive imports, deterministic analysis, provider
+  provenance, source reopening with matching hashes, and disconnect revocation.
   Outbound acceptance delivered one approved SMTP message to the controlled
   inbox, retained its audit record, and blocked duplicate dispatch.
 - Public branding is owner-approved and hash-bound in `release-acceptance.json`.

--- a/release-acceptance.json
+++ b/release-acceptance.json
@@ -31,6 +31,7 @@
       "evidence": [
         "codex-task:019f0b03-ca19-7f62-8f85-61a772f45256:owner-selected-google-plus-outbound-email",
         "runtime-acceptance:google:2026-08-14T08:51:14.710Z",
+        "runtime-acceptance:google-drive-evidence:2026-08-14T14:28:33.018Z",
         "runtime-acceptance:outboundEmail:2026-08-14T08:51:14.710Z"
       ],
       "scopeSelectedBy": "LARO product owner",
@@ -42,7 +43,7 @@
       "providerChecks": {
         "google": {
           "status": "passed",
-          "testedAt": "2026-08-14T08:51:14.710Z",
+          "testedAt": "2026-08-14T14:28:33.018Z",
           "evidence": [
             "runtime:google-client-configured",
             "database:google-account-connected",
@@ -53,6 +54,8 @@
             "google-api:drive-root-read:folders=32",
             "receipt:google-evidence-persisted-and-read",
             "receipt:google-source-opened-and-hash-matched",
+            "receipt:google-drive-evidence-persisted-and-read",
+            "receipt:google-drive-source-opened-and-hash-matched",
             "audit:provider.disconnect_revoked:count=1"
           ],
           "checks": [
@@ -62,6 +65,8 @@
             "driveRead",
             "evidencePersisted",
             "sourceLinkOpened",
+            "driveEvidencePersisted",
+            "driveSourceLinkOpened",
             "disconnectRevoked"
           ],
           "requiredChecks": [
@@ -71,6 +76,8 @@
             "driveRead",
             "evidencePersisted",
             "sourceLinkOpened",
+            "driveEvidencePersisted",
+            "driveSourceLinkOpened",
             "disconnectRevoked"
           ]
         },

--- a/scripts/release-acceptance.mjs
+++ b/scripts/release-acceptance.mjs
@@ -8,7 +8,17 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const GATE_NAMES = ['publicBrand', 'liveProviders'];
 const BRAND_ASSET_PATHS = ['build/icon.png', 'public/laro-logo.png'];
 export const PROVIDER_REQUIREMENTS = Object.freeze({
-  google: ['credentials', 'oauthConsent', 'gmailRead', 'driveRead', 'evidencePersisted', 'sourceLinkOpened', 'disconnectRevoked'],
+  google: [
+    'credentials',
+    'oauthConsent',
+    'gmailRead',
+    'driveRead',
+    'evidencePersisted',
+    'sourceLinkOpened',
+    'driveEvidencePersisted',
+    'driveSourceLinkOpened',
+    'disconnectRevoked',
+  ],
   outboundEmail: ['credentials', 'approvedSend', 'singleDelivery', 'auditRecorded', 'duplicateBlocked'],
   inboundEmail: ['credentials', 'replyReceived', 'threadedToOutreach', 'analyticsUpdated'],
   s3: ['credentials', 'put', 'read', 'hashMatched', 'delete', 'backupInventory'],

--- a/server/liveProviderAcceptance.ts
+++ b/server/liveProviderAcceptance.ts
@@ -16,6 +16,7 @@ import {
 import { verifyOutboundEmailConnection } from "./systemEmail";
 import {
   hashAcceptanceRecipient,
+  readGoogleDriveEvidenceAcceptanceReceipt,
   readGoogleEvidenceAcceptanceReceipt,
   readOutboundAcceptanceReceipt,
 } from "./providerAcceptanceEvidence";
@@ -27,6 +28,8 @@ const GOOGLE_REQUIREMENTS = [
   "driveRead",
   "evidencePersisted",
   "sourceLinkOpened",
+  "driveEvidencePersisted",
+  "driveSourceLinkOpened",
   "disconnectRevoked",
 ] as const;
 
@@ -197,6 +200,22 @@ export async function collectLiveProviderAcceptance(
     parsedAuditDetails(entry.details).provider === "google",
   ));
   const googleReceiptProven = googleReceiptMatchesAccount && googleReceiptAuditRecorded;
+  const driveReceipt = googleAccount?.userId
+    ? await readGoogleDriveEvidenceAcceptanceReceipt(googleAccount.userId)
+    : null;
+  const driveReceiptMatchesAccount = Boolean(
+    driveReceipt &&
+    googleAccount?.email &&
+    driveReceipt.accountEmailHash === hashAcceptanceRecipient(googleAccount.email),
+  );
+  const driveReceiptAuditRecorded = Boolean(driveReceipt && ownerAudits.some((entry) => {
+    const details = parsedAuditDetails(entry.details);
+    return entry.action === AUDIT_ACTIONS.PROVIDER_ACCEPTANCE_RECORDED &&
+      entry.entityId === driveReceipt.runId &&
+      details.provider === "google" &&
+      details.source === "google_drive";
+  }));
+  const driveReceiptProven = driveReceiptMatchesAccount && driveReceiptAuditRecorded;
 
   const googleChecks = {
     credentials: check(
@@ -233,6 +252,14 @@ export async function collectLiveProviderAcceptance(
       googleSourceOpenAudits.length > 0
         ? `audit:google-evidence.source_opened:count=${googleSourceOpenAudits.length}`
         : false,
+    ),
+    driveEvidencePersisted: check(
+      driveReceiptProven,
+      driveReceiptProven ? "receipt:google-drive-evidence-persisted-and-read" : false,
+    ),
+    driveSourceLinkOpened: check(
+      driveReceiptProven,
+      driveReceiptProven ? "receipt:google-drive-source-opened-and-hash-matched" : false,
     ),
     disconnectRevoked: check(
       auditCount(AUDIT_ACTIONS.PROVIDER_DISCONNECT_REVOKED) > 0,

--- a/tests/security/liveGoogleDriveEvidenceAcceptance.test.ts
+++ b/tests/security/liveGoogleDriveEvidenceAcceptance.test.ts
@@ -179,6 +179,20 @@ suite("live Google Drive evidence acceptance", () => {
     expect(JSON.stringify(receipt)).not.toContain(recipient);
     expect(JSON.stringify(receipt)).not.toContain("drive-file-acceptance-001");
 
+    const { collectLiveProviderAcceptance } = await import("../../server/liveProviderAcceptance");
+    const probe = await collectLiveProviderAcceptance({
+      listDriveFolders: async () => [{ id: "folder" }],
+      testGmail: async () => ({ ok: true, email: recipient }),
+      verifyOutbound: async () => ({ ok: false, provider: "unconfigured" }),
+      targetUserId: userId,
+      targetGoogleAccountId: accountId,
+    });
+    expect(probe.providers.google.checks.driveEvidencePersisted.passed).toBe(true);
+    expect(probe.providers.google.checks.driveSourceLinkOpened.passed).toBe(true);
+    expect(probe.providers.google.checks.driveEvidencePersisted.evidence).toContain(
+      "receipt:google-drive-evidence-persisted-and-read",
+    );
+
     const resumed = await runLiveGoogleDriveEvidenceAcceptance({
       userId,
       googleAccountId: accountId,

--- a/tests/security/liveProviderAcceptance.test.ts
+++ b/tests/security/liveProviderAcceptance.test.ts
@@ -33,7 +33,7 @@ suite("live provider acceptance evidence", () => {
     });
 
     expect(result.summary.status).toBe("pending");
-    expect(result.summary.pendingChecks).toHaveLength(12);
+    expect(result.summary.pendingChecks).toHaveLength(14);
     expect(result.providers.google.status).toBe("pending");
     expect(result.providers.outboundEmail.status).toBe("pending");
   });
@@ -126,6 +126,16 @@ suite("live provider acceptance evidence", () => {
         createdAt: now,
       },
     ]);
+    const { recordGoogleDriveEvidenceAcceptanceReceipt } = await import(
+      "../../server/providerAcceptanceEvidence"
+    );
+    await recordGoogleDriveEvidenceAcceptanceReceipt({
+      userId,
+      runId: "provider-drive-acceptance-001",
+      accountEmail: "private-owner@example.com",
+      sourceId: "private-drive-source-id",
+      verifiedAt: now,
+    });
 
     const providerDependencies: LiveProviderAcceptanceDependencies = {
       listDriveFolders: async () => [{ id: "folder" }] as any,

--- a/tests/security/releaseAcceptance.test.ts
+++ b/tests/security/releaseAcceptance.test.ts
@@ -9,7 +9,17 @@ const ROOT = join(__dirname, '..', '..');
 const packageVersion = '1.3.0';
 const temporaryDirectories: string[] = [];
 const providerRequirements = {
-  google: ['credentials', 'oauthConsent', 'gmailRead', 'driveRead', 'evidencePersisted', 'sourceLinkOpened', 'disconnectRevoked'],
+  google: [
+    'credentials',
+    'oauthConsent',
+    'gmailRead',
+    'driveRead',
+    'evidencePersisted',
+    'sourceLinkOpened',
+    'driveEvidencePersisted',
+    'driveSourceLinkOpened',
+    'disconnectRevoked',
+  ],
   outboundEmail: ['credentials', 'approvedSend', 'singleDelivery', 'auditRecorded', 'duplicateBlocked'],
 };
 
@@ -115,6 +125,33 @@ describe('release acceptance provider evidence', () => {
     const result = validate(record({ ...approval(), providerScope: [...providerScope], providerChecks }));
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('All recorded external acceptance gates are approved.');
+  });
+
+  it('rejects a legacy Google checklist without Drive document proof', () => {
+    const result = validate(record({
+      ...approval(),
+      providerScope: ['google'],
+      providerChecks: {
+        google: {
+          status: 'passed',
+          testedAt: new Date().toISOString(),
+          evidence: ['run:legacy-google-acceptance'],
+          checks: [
+            'credentials',
+            'oauthConsent',
+            'gmailRead',
+            'driveRead',
+            'evidencePersisted',
+            'sourceLinkOpened',
+            'disconnectRevoked',
+          ],
+        },
+      },
+    }));
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('driveEvidencePersisted');
+    expect(result.stderr).toContain('driveSourceLinkOpened');
   });
 
   it('prepares an unapproved provider draft with exact checks and brand hashes', () => {


### PR DESCRIPTION
## What changed

- make persisted Drive evidence and Drive source reopening required Google provider checks
- validate those checks only from the signed Drive receipt plus its acceptance audit
- record the successful target run from 2026-08-14 in `release-acceptance.json`
- mark target criterion M2 passed and reconcile the release verification documents
- extend provider tests so a Gmail-only fixture no longer passes the combined Google gate

## Evidence

The production run selected one globally unique Google document, imported and analyzed it, verified stored and signed-link bytes by SHA-256, confirmed the selected-account provider provenance row, recorded one source-open audit, and removed all temporary business rows and bytes. The retained receipt contains hashes rather than the filename, Drive ID, or account address.

## Validation

- full stabilization gate passed
- 78 test files and 442 tests passed
- release acceptance check passed
- all server/main/renderer typechecks, lint, dependency audits, safety scans, bundle budgets, traceability, and both recovery drills passed
- focused provider, Gmail, Drive, release-record, and production-readiness tests passed