### PR TITLE
Fix LARO ngrok process selection

### DIFF
--- a/scripts/start-ngrok-api.ps1
+++ b/scripts/start-ngrok-api.ps1
@@ -186,6 +186,26 @@ function Get-NgrokFailureMessage {
     }
 }
 
+function Get-LaroNgrokProcesses {
+    param(
+        [Parameter(Mandatory)] [string]$TargetUrl,
+        [string]$ReservedUrl = ""
+    )
+
+    $targetPattern = [regex]::Escape($TargetUrl)
+    $reservedPattern = if ($ReservedUrl) { [regex]::Escape("--url=$ReservedUrl") } else { "" }
+    $matches = @(Get-CimInstance Win32_Process -Filter "Name='ngrok.exe'" -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.CommandLine -match "(?:^|\s)http(?:\s|$)" -and
+            $_.CommandLine -match $targetPattern -and
+            $_.CommandLine -match [regex]::Escape("--name=laro-api") -and
+            (-not $reservedPattern -or $_.CommandLine -match $reservedPattern)
+        })
+    foreach ($match in $matches) {
+        Get-Process -Id $match.ProcessId -ErrorAction SilentlyContinue
+    }
+}
+
 function Wait-ForHttpsTunnel {
     param(
         [Parameter(Mandatory)] [Diagnostics.Process]$Process,
@@ -345,15 +365,20 @@ try {
     $httpsTunnel = $null
 }
 
-$existingNgrok = @(Get-Process ngrok -ErrorAction SilentlyContinue)
+$matchingProcesses = @(Get-LaroNgrokProcesses `
+    -TargetUrl "http://127.0.0.1:3000" `
+    -ReservedUrl $(if ($useDirectTunnel) { "" } else { $InternalUrl }))
 if ($httpsTunnel) {
-    if ($existingNgrok.Count -ne 1) {
+    if ($matchingProcesses.Count -ne 1) {
         throw "The LARO tunnel exists, but its local ngrok process could not be identified safely."
     }
-    $ngrokProcess = $existingNgrok[0]
+    $ngrokProcess = $matchingProcesses[0]
 } else {
-    if ($existingNgrok.Count -gt 0) {
-        throw "Another local ngrok process is already running without the expected LARO tunnel."
+    if ($matchingProcesses.Count -gt 0) {
+        throw "A LARO ngrok process is running without the expected tunnel. Stop that stale process before retrying."
+    }
+    if (@(Get-Process ngrok -ErrorAction SilentlyContinue).Count -gt 0) {
+        throw "Another local ngrok process owns the inspector while the LARO tunnel is absent. Start LARO after assigning a separate inspector endpoint."
     }
     $ngrokProcess = Start-Process -FilePath $ngrokExecutable `
         -ArgumentList $ngrokArguments `

--- a/scripts/start-ngrok-api.ps1
+++ b/scripts/start-ngrok-api.ps1
@@ -186,20 +186,29 @@ function Get-NgrokFailureMessage {
     }
 }
 
+function Test-CommandLineHasArgument {
+    param(
+        [Parameter(Mandatory)] [string]$CommandLine,
+        [Parameter(Mandatory)] [string]$Argument
+    )
+
+    $argumentPattern = "(?:^|\s)" + [regex]::Escape($Argument) + "(?=\s|$)"
+    return $CommandLine -match $argumentPattern
+}
+
 function Get-LaroNgrokProcesses {
     param(
         [Parameter(Mandatory)] [string]$TargetUrl,
         [string]$ReservedUrl = ""
     )
 
-    $targetPattern = [regex]::Escape($TargetUrl)
-    $reservedPattern = if ($ReservedUrl) { [regex]::Escape("--url=$ReservedUrl") } else { "" }
     $matches = @(Get-CimInstance Win32_Process -Filter "Name='ngrok.exe'" -ErrorAction SilentlyContinue |
         Where-Object {
-            $_.CommandLine -match "(?:^|\s)http(?:\s|$)" -and
-            $_.CommandLine -match $targetPattern -and
-            $_.CommandLine -match [regex]::Escape("--name=laro-api") -and
-            (-not $reservedPattern -or $_.CommandLine -match $reservedPattern)
+            (Test-CommandLineHasArgument -CommandLine $_.CommandLine -Argument "http") -and
+            (Test-CommandLineHasArgument -CommandLine $_.CommandLine -Argument $TargetUrl) -and
+            (Test-CommandLineHasArgument -CommandLine $_.CommandLine -Argument "--name=laro-api") -and
+            (-not $ReservedUrl -or
+                (Test-CommandLineHasArgument -CommandLine $_.CommandLine -Argument "--url=$ReservedUrl"))
         })
     foreach ($match in $matches) {
         Get-Process -Id $match.ProcessId -ErrorAction SilentlyContinue

--- a/tests/security/runtimeOperations.test.ts
+++ b/tests/security/runtimeOperations.test.ts
@@ -35,6 +35,9 @@ describe('production runtime operations', () => {
     expect(dockerfile).toContain('COPY scripts/runtime-readiness.mjs ./scripts/runtime-readiness.mjs');
     expect(launcher).toContain('exec -T laro-server npm run readiness:runtime');
     expect(launcher).toContain('function Get-LaroNgrokProcesses');
+    expect(launcher).toContain('function Test-CommandLineHasArgument');
+    expect(launcher).toContain('[regex]::Escape($Argument) + "(?=\\s|$)"');
+    expect(launcher).toContain('Test-CommandLineHasArgument -CommandLine $_.CommandLine -Argument "--name=laro-api"');
     expect(launcher).toContain('$matchingProcesses = @(Get-LaroNgrokProcesses');
     expect(launcher).not.toContain('$existingNgrok.Count -ne 1');
     expect(readiness).toContain("database.pragma('quick_check'");

--- a/tests/security/runtimeOperations.test.ts
+++ b/tests/security/runtimeOperations.test.ts
@@ -34,6 +34,9 @@ describe('production runtime operations', () => {
     expect(pkg.scripts['readiness:runtime']).toBe('node scripts/runtime-readiness.mjs');
     expect(dockerfile).toContain('COPY scripts/runtime-readiness.mjs ./scripts/runtime-readiness.mjs');
     expect(launcher).toContain('exec -T laro-server npm run readiness:runtime');
+    expect(launcher).toContain('function Get-LaroNgrokProcesses');
+    expect(launcher).toContain('$matchingProcesses = @(Get-LaroNgrokProcesses');
+    expect(launcher).not.toContain('$existingNgrok.Count -ne 1');
     expect(readiness).toContain("database.pragma('quick_check'");
     expect(readiness).toContain("path: '/api/integrations/hai/health'");
     expect(readiness).not.toContain('tsx');


### PR DESCRIPTION
## Summary

- identify the existing LARO ngrok process by its exact command-line ownership markers
- reuse the LARO tunnel even when an unrelated ngrok process is running
- retain fail-closed behavior when the expected tunnel or inspector ownership is ambiguous

## Verification

- 43 focused security and production-readiness tests passed
- PowerShell launcher syntax validated
- TypeScript typecheck passed
- live deployment completed and runtime readiness passed
- public health endpoint reports healthy while both ngrok processes remain running