### PR TITLE
Retry transient ngrok tunnel discovery

### DIFF
--- a/scripts/start-ngrok-api.ps1
+++ b/scripts/start-ngrok-api.ps1
@@ -215,6 +215,34 @@ function Get-LaroNgrokProcesses {
     }
 }
 
+function Find-ExistingLaroHttpsTunnel {
+    param(
+        [string]$ExpectedUrl = "",
+        [int]$Attempts = 4,
+        [int]$DelayMilliseconds = 500
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            $state = Invoke-RestMethod -Uri "http://127.0.0.1:4040/api/tunnels" -TimeoutSec 3
+            $httpsTunnel = @($state.tunnels) |
+                Where-Object {
+                    $_.name -eq "laro-api" -and
+                    $_.public_url -match "^https://" -and
+                    (-not $ExpectedUrl -or $_.public_url.TrimEnd("/") -eq $ExpectedUrl.TrimEnd("/"))
+                } |
+                Select-Object -First 1
+            if ($httpsTunnel) { return $httpsTunnel }
+        } catch {
+            # The local ngrok inspector can briefly lag while its tunnel remains healthy.
+        }
+        if ($attempt -lt $Attempts) {
+            Start-Sleep -Milliseconds $DelayMilliseconds
+        }
+    }
+    return $null
+}
+
 function Wait-ForHttpsTunnel {
     param(
         [Parameter(Mandatory)] [Diagnostics.Process]$Process,
@@ -358,21 +386,10 @@ $ngrokArguments = @(
 if (-not $useDirectTunnel) { $ngrokArguments += "--url=$InternalUrl" }
 
 $ngrokProcess = $null
-$httpsTunnel = $null
 $startedNgrok = $false
 
-try {
-    $existingState = Invoke-RestMethod -Uri "http://127.0.0.1:4040/api/tunnels" -TimeoutSec 3
-    $httpsTunnel = @($existingState.tunnels) |
-        Where-Object {
-            $_.name -eq "laro-api" -and
-            $_.public_url -match "^https://" -and
-            ($useDirectTunnel -or $_.public_url.TrimEnd("/") -eq $InternalUrl)
-        } |
-        Select-Object -First 1
-} catch {
-    $httpsTunnel = $null
-}
+$httpsTunnel = Find-ExistingLaroHttpsTunnel `
+    -ExpectedUrl $(if ($useDirectTunnel) { "" } else { $InternalUrl })
 
 $matchingProcesses = @(Get-LaroNgrokProcesses `
     -TargetUrl "http://127.0.0.1:3000" `

--- a/tests/security/runtimeOperations.test.ts
+++ b/tests/security/runtimeOperations.test.ts
@@ -35,6 +35,11 @@ describe('production runtime operations', () => {
     expect(dockerfile).toContain('COPY scripts/runtime-readiness.mjs ./scripts/runtime-readiness.mjs');
     expect(launcher).toContain('exec -T laro-server npm run readiness:runtime');
     expect(launcher).toContain('function Get-LaroNgrokProcesses');
+    expect(launcher).toContain('function Find-ExistingLaroHttpsTunnel');
+    expect(launcher).toContain('[int]$Attempts = 4');
+    expect(launcher).toContain('[int]$DelayMilliseconds = 500');
+    expect(launcher).toContain('$httpsTunnel = Find-ExistingLaroHttpsTunnel `');
+    expect(launcher).not.toContain('$existingState = Invoke-RestMethod -Uri "http://127.0.0.1:4040/api/tunnels" -TimeoutSec 3');
     expect(launcher).toContain('function Test-CommandLineHasArgument');
     expect(launcher).toContain('[regex]::Escape($Argument) + "(?=\\s|$)"');
     expect(launcher).toContain('Test-CommandLineHasArgument -CommandLine $_.CommandLine -Argument "--name=laro-api"');


### PR DESCRIPTION
## What changed
- retry discovery of an already-running LARO HTTPS tunnel across four bounded inspector reads
- continue to require the exact `laro-api` name and expected HTTPS URL before reusing a tunnel
- preserve the existing fail-closed process ownership checks after discovery retries are exhausted
- add a regression guard that prevents reintroducing the one-shot inspector lookup

## Root cause
The deployment launcher treated a single transient ngrok inspector miss as authoritative. A healthy, correctly identified LARO ngrok process could therefore be labelled stale even though its tunnel remained active.

## Verification
- regression test failed before implementation and passed after it
- `npm test -- --run tests/security/runtimeOperations.test.ts tests/security/productionReadiness.test.ts` (43 tests)
- PowerShell parser validation
- live `start-ngrok-api.ps1 -SkipBuild` against the existing tunnel, including runtime and public health checks
- `npm run gate` (85 files, 470 tests)