### PR TITLE
Harden OAuth state resource handling

### DIFF
--- a/docs/NO_EXCUSES_SEARCH.md
+++ b/docs/NO_EXCUSES_SEARCH.md
@@ -41,7 +41,7 @@ Descriptive words (mock/stub/placeholder/fake) needing human judgement. Triage o
 | `server/_core/env.ts` | 101 | `* in production and the secrets are still the shipped placeholders (or empty),` |
 | `server/_core/env.ts` | 133 | `* to the insecure placeholder. Returns a list of non-fatal warnings (e.g.` |
 
-## Markers in tests / scripts / renderer (249) — reported, not failing
+## Markers in tests / scripts / renderer (250) — reported, not failing
 
 These are informational and do not identify unsupported runtime behavior by themselves; test/script occurrences are usually the words "mock"/"fake" used descriptively.
 
@@ -57,9 +57,9 @@ These are informational and do not identify unsupported runtime behavior by them
 | `tests/backend/oauthTokenRetry.test.ts` | 8 |
 | `src/renderer/components/SmartSearchFilters.tsx` | 7 |
 | `tests/backend/kvkIntegration.test.ts` | 6 |
+| `tests/security/productionReadiness.test.ts` | 6 |
 | `src/renderer/components/AuthPage.tsx` | 5 |
 | `src/renderer/components/EvidenceFilters.tsx` | 5 |
-| `tests/security/productionReadiness.test.ts` | 5 |
 | `src/renderer/components/EvidenceSearch.tsx` | 4 |
 | `tests/backend/outreachDirectory.test.ts` | 4 |
 | `tests/backend/wettenOverheid.test.ts` | 4 |

--- a/server/crypto.ts
+++ b/server/crypto.ts
@@ -22,28 +22,32 @@ function secret(): string {
   return ENV.JWT_SECRET || ENV.COOKIE_SECRET || 'insecure-dev-secret-change-me-please';
 }
 
-function deriveKey(): Buffer {
-  // scrypt is a proper password-based KDF; deterministic given the same secret.
-  return crypto.scryptSync(secret(), KDF_SALT, 32);
-}
+// Derive once while the server module graph is loading. Repeating this
+// memory-hard operation inside public OAuth callback requests can block the
+// event loop and turn malformed callback traffic into resource exhaustion.
+const TOKEN_KEY = crypto.scryptSync(secret(), KDF_SALT, 32);
 
 /** Encrypt a UTF-8 string with AES-256-GCM. Returns `gcm1:iv:tag:ciphertext` (hex). */
 export function encryptSecret(plaintext: string): string {
   if (!plaintext) return '';
   const iv = crypto.randomBytes(IV_LEN);
-  const cipher = crypto.createCipheriv(GCM_ALGO, deriveKey(), iv);
+  const cipher = crypto.createCipheriv(GCM_ALGO, TOKEN_KEY, iv);
   const enc = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
   const tag = cipher.getAuthTag();
   return [PREFIX, iv.toString('hex'), tag.toString('hex'), enc.toString('hex')].join(':');
 }
 
 /** Decrypt a value produced by encryptSecret, transparently handling legacy CBC. */
-export function decryptSecret(value: string): string {
+export interface DecryptSecretOptions {
+  logFailure?: boolean;
+}
+
+export function decryptSecret(value: string, options: DecryptSecretOptions = {}): string {
   if (!value) return '';
   try {
     if (value.startsWith(PREFIX + ':')) {
       const [, ivHex, tagHex, dataHex] = value.split(':');
-      const decipher = crypto.createDecipheriv(GCM_ALGO, deriveKey(), Buffer.from(ivHex, 'hex'));
+      const decipher = crypto.createDecipheriv(GCM_ALGO, TOKEN_KEY, Buffer.from(ivHex, 'hex'));
       decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
       return Buffer.concat([decipher.update(Buffer.from(dataHex, 'hex')), decipher.final()]).toString('utf8');
     }
@@ -57,7 +61,9 @@ export function decryptSecret(value: string): string {
       return Buffer.concat([decipher.update(Buffer.from(parts.join(':'), 'hex')), decipher.final()]).toString('utf8');
     }
   } catch (err) {
-    console.error('[crypto] decryptSecret failed:', err instanceof Error ? err.message : err);
+    if (options.logFailure !== false) {
+      console.error('[crypto] decryptSecret failed:', err instanceof Error ? err.message : err);
+    }
   }
   return '';
 }

--- a/server/emailOAuth.ts
+++ b/server/emailOAuth.ts
@@ -1,5 +1,5 @@
 import { ENV } from './_core/env';
-import { encryptSecret, decryptSecret } from './crypto';
+import { encryptSecret, decryptSecret, type DecryptSecretOptions } from './crypto';
 
 /**
  * Token Encryption & OAuth Refresh Utilities.
@@ -16,8 +16,8 @@ export function encryptToken(text: string): string {
 }
 
 /** Decrypt a stored OAuth token (handles both the current and legacy schemes). */
-export function decryptToken(text: string): string {
-  return decryptSecret(text);
+export function decryptToken(text: string, options?: DecryptSecretOptions): string {
+  return decryptSecret(text, options);
 }
 
 /**

--- a/server/oauth2.ts
+++ b/server/oauth2.ts
@@ -31,6 +31,13 @@ export interface EmailAccountInfo {
 
 type OAuthProvider = "gmail" | "outlook";
 
+export class OAuthStateError extends Error {
+  constructor() {
+    super("Invalid or expired OAuth state");
+    this.name = "OAuthStateError";
+  }
+}
+
 
 interface OAuthStatePayload {
   userId: string;
@@ -41,6 +48,10 @@ interface OAuthStatePayload {
 }
 
 const OAUTH_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const OAUTH_STATE_MAX_LENGTH = 2_048;
+const OAUTH_STATE_PATTERN = /^[A-Za-z0-9_-]+$/;
+const OAUTH_GCM_ENVELOPE_PATTERN = /^gcm1:[0-9a-f]{24}:[0-9a-f]{32}:(?:[0-9a-f]{2})+$/;
+const OAUTH_LEGACY_CBC_ENVELOPE_PATTERN = /^[0-9a-f]{32}:(?:[0-9a-f]{32})+$/;
 const TOKEN_EXCHANGE_DNS_RETRY_DELAYS_MS = [250, 750, 1_500] as const;
 const OAUTH_PROVIDER_TIMEOUT_MS = 20_000;
 
@@ -198,12 +209,27 @@ export function consumeOAuthState(
   state: string,
   provider: OAuthProvider
 ): { userId: string; codeVerifier: string } {
+  if (
+    !state ||
+    state.length > OAUTH_STATE_MAX_LENGTH ||
+    !OAUTH_STATE_PATTERN.test(state)
+  ) {
+    throw new OAuthStateError();
+  }
+
   let payload: OAuthStatePayload;
   try {
-    const decrypted = decryptToken(fromBase64Url(state).toString("utf8"));
+    const encryptedState = fromBase64Url(state).toString("utf8");
+    if (
+      !OAUTH_GCM_ENVELOPE_PATTERN.test(encryptedState) &&
+      !OAUTH_LEGACY_CBC_ENVELOPE_PATTERN.test(encryptedState)
+    ) {
+      throw new OAuthStateError();
+    }
+    const decrypted = decryptToken(encryptedState, { logFailure: false });
     payload = JSON.parse(decrypted) as OAuthStatePayload;
   } catch {
-    throw new Error("Invalid or expired OAuth state");
+    throw new OAuthStateError();
   }
 
   if (
@@ -212,15 +238,15 @@ export function consumeOAuthState(
     typeof payload.codeVerifier !== "string" ||
     typeof payload.createdAt !== "number"
   ) {
-    throw new Error("Invalid or expired OAuth state");
+    throw new OAuthStateError();
   }
 
   if (Date.now() - payload.createdAt > OAUTH_STATE_TTL_MS) {
-    throw new Error("Invalid or expired OAuth state");
+    throw new OAuthStateError();
   }
 
   if (payload.provider !== provider) {
-    throw new Error("OAuth provider mismatch");
+    throw new OAuthStateError();
   }
 
   return { userId: payload.userId, codeVerifier: payload.codeVerifier };

--- a/server/oauth2Callbacks.ts
+++ b/server/oauth2Callbacks.ts
@@ -5,6 +5,7 @@ import {
   exchangeCodeForTokens,
   getAccountInfo,
   isRetryableOAuthNetworkError,
+  OAuthStateError,
   saveEmailAccount,
 } from './oauth2';
 
@@ -111,15 +112,20 @@ function callbackHandler(provider: OAuthProvider) {
         message: `${accountInfo.email} is connected to LARO.`,
       });
     } catch (error) {
-      console.error(`[OAuth2] ${provider} callback failed:`, error);
+      const invalidState = error instanceof OAuthStateError;
+      if (!invalidState) {
+        console.error(`[OAuth2] ${provider} callback failed:`, error);
+      }
       const retryable = !tokenExchangeCompleted && isRetryableOAuthNetworkError(error);
       sendCallbackPage(res, {
         success: false,
         title: 'Connection failed',
-        message: retryable
+        message: invalidState
+          ? 'The authorization request is invalid or has expired. Return to LARO and start the connection again.'
+          : retryable
           ? 'The provider could not be reached temporarily. Retry this connection without starting over.'
           : 'The connection could not be completed. Return to LARO and try again.',
-        status: retryable ? 503 : 500,
+        status: invalidState ? 400 : retryable ? 503 : 500,
         retry: retryable,
       });
     }

--- a/tests/backend/oauthCallbackResponse.test.ts
+++ b/tests/backend/oauthCallbackResponse.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from "node:http";
 import express from "express";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import oauth2CallbacksRouter from "../../server/oauth2Callbacks";
 
 describe("OAuth callback response", () => {
@@ -36,5 +36,27 @@ describe("OAuth callback response", () => {
     expect(body).toContain("window.close()");
     expect(body).not.toContain("code=");
     expect(body).not.toContain("state=");
+
+    const malformedEnvelope = Buffer.from("gcm1:x:x:x", "utf8").toString("base64url");
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const invalidStateResponse = await fetch(
+      `http://127.0.0.1:${address.port}/api/oauth/gmail/callback?code=provider-code&state=${malformedEnvelope}`,
+    );
+    const invalidStateBody = await invalidStateResponse.text();
+    expect(invalidStateResponse.status).toBe(400);
+    expect(invalidStateBody).toContain("Connection failed");
+    expect(invalidStateBody).not.toContain("provider-code");
+    expect(invalidStateBody).not.toContain(malformedEnvelope);
+
+    const tamperedEnvelope = Buffer.from(
+      `gcm1:${"0".repeat(24)}:${"0".repeat(32)}:${"00".repeat(16)}`,
+      "utf8",
+    ).toString("base64url");
+    const tamperedStateResponse = await fetch(
+      `http://127.0.0.1:${address.port}/api/oauth/gmail/callback?code=provider-code&state=${tamperedEnvelope}`,
+    );
+    expect(tamperedStateResponse.status).toBe(400);
+    expect(await tamperedStateResponse.text()).not.toContain(tamperedEnvelope);
+    expect(errorLog).not.toHaveBeenCalled();
   });
 });

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { spawnSync } from 'child_process';
+import crypto from 'crypto';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -206,6 +207,36 @@ describe('production readiness regressions', () => {
     const state = authUrl.searchParams.get('state');
     expect(state).toBeTruthy();
     expect(consumeOAuthState(state!, 'gmail').userId).toBe('USER_TEST');
+    expect(() => consumeOAuthState(`${state!}!`, 'gmail')).toThrow('Invalid or expired OAuth state');
+  });
+
+  it('derives the token-encryption key once instead of on every crypto operation', async () => {
+    vi.resetModules();
+    const scryptSpy = vi.spyOn(crypto, 'scryptSync');
+    const { decryptSecret, encryptSecret } = await import('../../server/crypto');
+    const derivationsAtStartup = scryptSpy.mock.calls.length;
+
+    const first = encryptSecret('first-token');
+    const second = encryptSecret('second-token');
+    expect(decryptSecret(first)).toBe('first-token');
+    expect(decryptSecret(second)).toBe('second-token');
+    expect(derivationsAtStartup).toBe(1);
+    expect(scryptSpy).toHaveBeenCalledTimes(derivationsAtStartup);
+  });
+
+  it('decrypts ciphertext written before token-key caching was introduced', async () => {
+    process.env.JWT_SECRET = 'compatibility-fixture-secret-32-characters';
+    process.env.COOKIE_SECRET = 'compatibility-cookie-secret-32-characters';
+    vi.resetModules();
+    const { decryptSecret } = await import('../../server/crypto');
+    const existingCiphertext = [
+      'gcm1',
+      '00112233445566778899aabb',
+      'a991d215bd764f3801c6ebac5d2f4091',
+      '6365554e2fceb002fbe37f4846416e440d5ea9',
+    ].join(':');
+
+    expect(decryptSecret(existingCiphertext)).toBe('fixture-oauth-token');
   });
 
   it('requests evidence-read OAuth permissions without delegated mail sending or label writes', async () => {


### PR DESCRIPTION
## Summary
- derive the AES-GCM token key once during server module startup instead of on every OAuth callback operation
- strictly bound and validate OAuth state plus its decoded encrypted envelope before decryption
- return generic HTTP 400 pages for invalid or expired state and suppress expected attacker-controlled decrypt logs
- preserve existing GCM and legacy CBC compatibility, with a fixed pre-change ciphertext fixture

## Security invariant
Unauthenticated OAuth callback traffic cannot trigger repeated memory-hard key derivation, unbounded state decoding, or expected-failure log amplification.

## Verification
- red/green regression tests for permissive base64 state parsing, repeated scrypt derivation, malformed callback status, and log amplification
- focused security tests: 54 passed
- `npm.cmd run gate`: 87 files, 501 tests; all blocking stabilization gates passed
- independent security/correctness review: no blocking or important findings remain