### PR TITLE
Stream and bound evidence ZIP exports

### DIFF
--- a/server/evidenceExport.ts
+++ b/server/evidenceExport.ts
@@ -1,8 +1,59 @@
 import archiver from "archiver";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
+import { PassThrough, Readable, Transform } from "stream";
+import { pipeline } from "stream/promises";
+import { randomBytes } from "crypto";
 import { getDb } from "./db";
 import { cases, documentAnalyses, evidence } from "./schema";
-import { sanitizeFilename, storageRead } from "./storage";
+import { sanitizeFilename, storageOpenReadStream } from "./storage";
+import { MAX_EVIDENCE_FILE_BYTES } from "../shared/evidenceFiles";
+
+const MAX_EXPORT_EVIDENCE_ITEMS = 1_000;
+const MAX_EXPORT_SOURCE_BYTES = 512 * 1024 * 1024;
+const MAX_EXPORT_ARCHIVE_BYTES = 600 * 1024 * 1024;
+const EXPORT_TIMEOUT_MS = 15 * 60 * 1000;
+const MAX_ACTIVE_EXPORTS = 1;
+const MAX_QUEUED_EXPORTS = 2;
+const EXPORT_TICKET_TTL_MS = 2 * 60 * 1000;
+const MAX_EXPORT_TICKETS = 100;
+const MAX_EXPORT_TICKETS_PER_USER = 5;
+const MAX_GENERATED_ENTRY_BYTES = 8 * 1024 * 1024;
+const MAX_GENERATED_TOTAL_BYTES = 64 * 1024 * 1024;
+let activeExports = 0;
+type ExportWaiter = {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+};
+const exportWaiters: ExportWaiter[] = [];
+const exportTickets = new Map<string, { userId: string; caseId: string; expiresAt: number }>();
+
+export function issueCaseZipDownloadTicket(userId: string, caseId: string): string {
+  const now = Date.now();
+  for (const [token, ticket] of exportTickets) {
+    if (ticket.expiresAt <= now) exportTickets.delete(token);
+  }
+  if (exportTickets.size >= MAX_EXPORT_TICKETS) {
+    throw new Error("Evidence export ticket capacity is full; retry shortly");
+  }
+  const userTicketCount = [...exportTickets.values()].filter((ticket) => ticket.userId === userId).length;
+  if (userTicketCount >= MAX_EXPORT_TICKETS_PER_USER) {
+    throw new Error("Too many pending evidence export links; use or wait for an existing link");
+  }
+  const token = randomBytes(32).toString("base64url");
+  exportTickets.set(token, { userId, caseId, expiresAt: now + EXPORT_TICKET_TTL_MS });
+  return token;
+}
+
+export function consumeCaseZipDownloadTicket(token: string, userId: string): string {
+  const ticket = exportTickets.get(token);
+  exportTickets.delete(token);
+  if (!ticket || ticket.expiresAt <= Date.now() || ticket.userId !== userId) {
+    throw new Error("Evidence export link is invalid or expired");
+  }
+  return ticket.caseId;
+}
 
 const SENSITIVE_METADATA_FIELDS = new Set([
   "accesstoken",
@@ -49,22 +100,68 @@ function csvCell(value: unknown): string {
   return /[",\r\n]/.test(rendered) ? `"${rendered.replace(/"/g, '""')}"` : rendered;
 }
 
-async function loadCaseExportRows(userId: string, caseId: string) {
+function throwIfExportAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error ? signal.reason : new Error("Evidence export was cancelled");
+}
+
+async function loadCaseExportRows(
+  userId: string,
+  caseId: string,
+  options: { includeAnalyses: boolean; signal?: AbortSignal },
+) {
+  throwIfExportAborted(options.signal);
   const db = await getDb();
   const [caseRow] = await db
     .select()
     .from(cases)
     .where(and(eq(cases.id, caseId), eq(cases.userId, userId)))
     .limit(1);
+  throwIfExportAborted(options.signal);
   if (!caseRow) throw new Error("Case not found");
-  const [items, analyses] = await Promise.all([
-    db.select().from(evidence).where(and(eq(evidence.caseId, caseId), eq(evidence.userId, userId))),
-    db.select().from(documentAnalyses).where(and(
+  const itemSizes = await db.select({
+      id: evidence.id,
+      generatedBytes: sql<number>`
+        length(CAST(coalesce(${evidence.id}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.title}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.type}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.source}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.description}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.fileUrl}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.fileName}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.fileSize}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.mimeType}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.metadata}, '') AS BLOB)) +
+        length(CAST(coalesce(${evidence.tags}, '') AS BLOB))
+      `,
+    }).from(evidence).where(and(eq(evidence.caseId, caseId), eq(evidence.userId, userId))).limit(MAX_EXPORT_EVIDENCE_ITEMS + 1);
+  throwIfExportAborted(options.signal);
+  const analysisRefs = options.includeAnalyses
+    ? await db.select({
+      id: documentAnalyses.id,
+      evidenceId: documentAnalyses.evidenceId,
+      resultBytes: sql<number>`length(CAST(${documentAnalyses.result} AS BLOB))`,
+    }).from(documentAnalyses).where(and(
       eq(documentAnalyses.caseId, caseId),
       eq(documentAnalyses.userId, userId)
-    )),
-  ]);
-  return { caseRow, items, analyses };
+    )).limit(MAX_EXPORT_EVIDENCE_ITEMS + 1)
+    : [];
+  throwIfExportAborted(options.signal);
+  if (itemSizes.length > MAX_EXPORT_EVIDENCE_ITEMS || analysisRefs.length > MAX_EXPORT_EVIDENCE_ITEMS) {
+    throw new Error(`Case export exceeds the ${MAX_EXPORT_EVIDENCE_ITEMS} item limit`);
+  }
+  const preflightGeneratedBytes = [...itemSizes.map((item) => item.generatedBytes), ...analysisRefs.map((item) => item.resultBytes)];
+  if (preflightGeneratedBytes.some((bytes) => !Number.isSafeInteger(bytes) || bytes > MAX_GENERATED_ENTRY_BYTES) ||
+      preflightGeneratedBytes.reduce((total, bytes) => total + bytes, 0) > MAX_GENERATED_TOTAL_BYTES) {
+    throw new Error("Case export generated content exceeds the 64 MB processing limit");
+  }
+  const items = await db
+    .select()
+    .from(evidence)
+    .where(and(eq(evidence.caseId, caseId), eq(evidence.userId, userId)))
+    .limit(MAX_EXPORT_EVIDENCE_ITEMS);
+  throwIfExportAborted(options.signal);
+  return { db, caseRow, items, analysisRefs };
 }
 
 function renderCaseCsv(items: Array<typeof evidence.$inferSelect>): Buffer {
@@ -99,82 +196,287 @@ function renderCaseCsv(items: Array<typeof evidence.$inferSelect>): Buffer {
 }
 
 export async function buildCaseCsv(userId: string, caseId: string): Promise<Buffer> {
-  const { items } = await loadCaseExportRows(userId, caseId);
+  const { items } = await loadCaseExportRows(userId, caseId, { includeAnalyses: false });
   return renderCaseCsv(items);
 }
 
-export async function buildCaseZip(userId: string, caseId: string): Promise<Buffer> {
-  const { caseRow, items, analyses } = await loadCaseExportRows(userId, caseId);
-  const analysisByEvidence = new Map(analyses.map((analysis) => [analysis.evidenceId, analysis]));
-  const sourceFiles: Array<{ name: string; bytes: Buffer }> = [];
+async function acquireExportSlot(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) throw new Error("Evidence export was cancelled");
+  if (activeExports < MAX_ACTIVE_EXPORTS) {
+    activeExports += 1;
+    return;
+  }
+  if (exportWaiters.length >= MAX_QUEUED_EXPORTS) {
+    throw new Error("Evidence export queue is full; retry after the current export finishes");
+  }
+  await new Promise<void>((resolve, reject) => {
+    const waiter: ExportWaiter = { resolve, reject, signal };
+    waiter.onAbort = () => {
+      const index = exportWaiters.indexOf(waiter);
+      if (index >= 0) exportWaiters.splice(index, 1);
+      reject(new Error("Evidence export was cancelled"));
+    };
+    signal?.addEventListener("abort", waiter.onAbort, { once: true });
+    exportWaiters.push(waiter);
+  });
+}
 
-  for (const item of items) {
-    const metadata = parseMetadata(item.metadata);
-    if (typeof metadata.storageKey !== "string" || !metadata.storageKey) continue;
-    try {
-      const bytes = await storageRead(metadata.storageKey);
-      const sourceName = sanitizeFilename(item.fileName || item.title || `${item.id}.bin`);
-      sourceFiles.push({ name: `files/${item.id}-${sourceName}`, bytes });
-    } catch {
-      // Keep the metadata export usable when a legacy source object is unavailable.
+function releaseExportSlot(): void {
+  while (exportWaiters.length) {
+    const next = exportWaiters.shift()!;
+    next.signal?.removeEventListener("abort", next.onAbort!);
+    if (next.signal?.aborted) {
+      next.reject(new Error("Evidence export was cancelled"));
+      continue;
+    }
+    next.resolve();
+    return;
+  }
+  activeExports -= 1;
+}
+
+function appendStreamEntry(
+  archive: archiver.Archiver,
+  source: Readable,
+  name: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      archive.off("entry", onEntry);
+      archive.off("error", onError);
+      source.off("error", onError);
+    };
+    const onEntry = (entry: { name?: string }) => {
+      if (entry.name !== name) return;
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      source.destroy(error);
+      reject(error);
+    };
+    archive.on("entry", onEntry);
+    archive.on("error", onError);
+    source.on("error", onError);
+    archive.append(source, { name });
+  });
+}
+
+async function appendGeneratedEntry(
+  archive: archiver.Archiver,
+  name: string,
+  value: string | Buffer,
+  budget: { bytes: number },
+): Promise<void> {
+  const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value, "utf8");
+  if (bytes.length > MAX_GENERATED_ENTRY_BYTES) {
+    throw new Error(`Evidence ZIP entry ${name} exceeds the 8 MB generated-entry limit`);
+  }
+  budget.bytes += bytes.length;
+  if (budget.bytes > MAX_GENERATED_TOTAL_BYTES) {
+    throw new Error("Evidence ZIP generated content exceeds the 64 MB processing limit");
+  }
+  await appendStreamEntry(archive, Readable.from([bytes]), name);
+}
+
+export type CaseZipStream = {
+  filename: string;
+  stream: Readable;
+  completion: Promise<{ bytes: number; sourceFileCount: number }>;
+};
+
+export async function createCaseZipStream(
+  userId: string,
+  caseId: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<CaseZipStream> {
+  await acquireExportSlot(options.signal);
+  const lifecycle = new AbortController();
+  const cancelFromCaller = () => lifecycle.abort(
+    options.signal?.reason instanceof Error
+      ? options.signal.reason
+      : new Error("Evidence export was cancelled"),
+  );
+  options.signal?.addEventListener("abort", cancelFromCaller, { once: true });
+  if (options.signal?.aborted) cancelFromCaller();
+  const timeout = setTimeout(
+    () => lifecycle.abort(new Error("Evidence ZIP exceeded the 15 minute processing limit")),
+    EXPORT_TIMEOUT_MS,
+  );
+  let slotTransferred = false;
+  try {
+    throwIfExportAborted(lifecycle.signal);
+    const { db, caseRow, items, analysisRefs } = await loadCaseExportRows(userId, caseId, {
+      includeAnalyses: true,
+      signal: lifecycle.signal,
+    });
+    const analysisByEvidence = new Map(analysisRefs.map((analysis) => [analysis.evidenceId, analysis]));
+    const output = new PassThrough({ highWaterMark: 64 * 1024 });
+    const archive = archiver("zip", { zlib: { level: 9 } });
+    let archiveBytes = 0;
+    let currentSource: Readable | null = null;
+    const archiveLimiter = new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        archiveBytes += chunk.length;
+        callback(
+          archiveBytes > MAX_EXPORT_ARCHIVE_BYTES
+            ? new Error("Evidence ZIP exceeds the 600 MB archive limit")
+            : null,
+          chunk,
+        );
+      },
+    });
+    const pipePromise = pipeline(archive, archiveLimiter, output);
+    const cancel = (error: Error) => {
+      currentSource?.destroy(error);
+      archive.abort();
+      output.destroy(error);
+    };
+    const onAbort = () => cancel(
+      lifecycle.signal.reason instanceof Error
+        ? lifecycle.signal.reason
+        : new Error("Evidence export was cancelled"),
+    );
+    lifecycle.signal.addEventListener("abort", onAbort, { once: true });
+
+    const completion = (async () => {
+      let sourceFileCount = 0;
+      let sourceBytes = 0;
+      const generatedBudget = { bytes: 0 };
+      try {
+        await appendGeneratedEntry(archive, "evidence.csv", renderCaseCsv(items), generatedBudget);
+        await appendGeneratedEntry(
+          archive,
+          "README.txt",
+          "LARO case evidence export.\n\nmanifest.json lists provenance and analysis coverage.\nevidence.csv is a spreadsheet-ready index.\nfiles/ contains available source documents.\nanalysis/ contains source-linked document analyses.\n",
+          generatedBudget,
+        );
+        for (const item of items) {
+          throwIfExportAborted(lifecycle.signal);
+          await appendGeneratedEntry(
+            archive,
+            `evidence/${item.id}.json`,
+            JSON.stringify({ ...item, metadata: redactMetadata(parseMetadata(item.metadata)) }, null, 2),
+            generatedBudget,
+          );
+          const analysisRef = analysisByEvidence.get(item.id);
+          if (analysisRef) {
+            const [analysis] = await db
+              .select({ result: documentAnalyses.result })
+              .from(documentAnalyses)
+              .where(and(
+                eq(documentAnalyses.id, analysisRef.id),
+                eq(documentAnalyses.caseId, caseId),
+                eq(documentAnalyses.userId, userId),
+              ))
+              .limit(1);
+            if (analysis) {
+              await appendGeneratedEntry(
+                archive,
+                `analysis/${item.id}.json`,
+                analysis.result,
+                generatedBudget,
+              );
+            }
+          }
+        }
+        for (const item of items) {
+          throwIfExportAborted(lifecycle.signal);
+          const metadata = parseMetadata(item.metadata);
+          if (typeof metadata.storageKey !== "string" || !metadata.storageKey) continue;
+          let source;
+          try {
+            source = await storageOpenReadStream(metadata.storageKey, {
+              maxBytes: MAX_EVIDENCE_FILE_BYTES,
+              signal: lifecycle.signal,
+            });
+            throwIfExportAborted(lifecycle.signal);
+          } catch (error) {
+            if (error instanceof Error && /limit/.test(error.message)) throw error;
+            continue;
+          }
+          currentSource = source.stream;
+          if (source.declaredBytes !== null && sourceBytes + source.declaredBytes > MAX_EXPORT_SOURCE_BYTES) {
+            const error = new Error("Evidence ZIP exceeds the 512 MB aggregate source limit");
+            source.stream.destroy(error);
+            await source.completion.catch(() => undefined);
+            throw error;
+          }
+          const aggregateLimiter = new Transform({
+            transform(chunk: Buffer, _encoding, callback) {
+              sourceBytes += chunk.length;
+              callback(
+                sourceBytes > MAX_EXPORT_SOURCE_BYTES
+                  ? new Error("Evidence ZIP exceeds the 512 MB aggregate source limit")
+                  : null,
+                chunk,
+              );
+            },
+          });
+          const aggregatePipeline = pipeline(source.stream, aggregateLimiter);
+          const sourceName = sanitizeFilename(item.fileName || item.title || `${item.id}.bin`);
+          await Promise.all([
+            appendStreamEntry(archive, aggregateLimiter, `files/${item.id}-${sourceName}`),
+            source.completion,
+            aggregatePipeline,
+          ]);
+          currentSource = null;
+          sourceFileCount += 1;
+        }
+        const manifest = {
+          format: "laro-case-evidence/v2",
+          generatedAt: new Date().toISOString(),
+          case: {
+            id: caseRow.id,
+            clientName: caseRow.clientName,
+            caseType: caseRow.caseType,
+            caseSummary: caseRow.caseSummary,
+            legalAreas: caseRow.legalAreas,
+            status: caseRow.status,
+          },
+          evidenceCount: items.length,
+          analyzedEvidenceCount: analysisRefs.length,
+          sourceFileCount,
+          evidence: items.map((item) => {
+            const metadata = parseMetadata(item.metadata);
+            return {
+              id: item.id,
+              title: item.title,
+              type: item.type,
+              source: item.source,
+              fileName: item.fileName,
+              mimeType: item.mimeType,
+              relevant: item.relevant,
+              relevanceScore: metadata.relevanceScore ?? null,
+              contentHash: metadata.contentHash ?? null,
+              analyzed: analysisByEvidence.has(item.id),
+            };
+          }),
+        };
+        await appendGeneratedEntry(archive, "manifest.json", JSON.stringify(manifest, null, 2), generatedBudget);
+        await archive.finalize();
+        await pipePromise;
+        return { bytes: archiveBytes, sourceFileCount };
+      } catch (error) {
+        cancel(error as Error);
+        await pipePromise.catch(() => undefined);
+        throw error;
+      } finally {
+        currentSource?.destroy();
+        clearTimeout(timeout);
+        lifecycle.signal.removeEventListener("abort", onAbort);
+        options.signal?.removeEventListener("abort", cancelFromCaller);
+        releaseExportSlot();
+      }
+    })();
+    slotTransferred = true;
+    return { filename: `case-${caseId}-evidence.zip`, stream: output, completion };
+  } finally {
+    if (!slotTransferred) {
+      clearTimeout(timeout);
+      options.signal?.removeEventListener("abort", cancelFromCaller);
+      releaseExportSlot();
     }
   }
-
-  const manifest = {
-    format: "laro-case-evidence/v2",
-    generatedAt: new Date().toISOString(),
-    case: {
-      id: caseRow.id,
-      clientName: caseRow.clientName,
-      caseType: caseRow.caseType,
-      caseSummary: caseRow.caseSummary,
-      legalAreas: caseRow.legalAreas,
-      status: caseRow.status,
-    },
-    evidenceCount: items.length,
-    analyzedEvidenceCount: analyses.length,
-    sourceFileCount: sourceFiles.length,
-    evidence: items.map((item) => {
-      const metadata = parseMetadata(item.metadata);
-      return {
-        id: item.id,
-        title: item.title,
-        type: item.type,
-        source: item.source,
-        fileName: item.fileName,
-        mimeType: item.mimeType,
-        relevant: item.relevant,
-        relevanceScore: metadata.relevanceScore ?? null,
-        contentHash: metadata.contentHash ?? null,
-        analyzed: analysisByEvidence.has(item.id),
-      };
-    }),
-  };
-  const csv = renderCaseCsv(items);
-
-  return new Promise<Buffer>((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    const archive = archiver("zip", { zlib: { level: 9 } });
-    archive.on("data", (chunk) => chunks.push(chunk as Buffer));
-    archive.on("error", reject);
-    archive.on("end", () => resolve(Buffer.concat(chunks)));
-
-    archive.append(JSON.stringify(manifest, null, 2), { name: "manifest.json" });
-    archive.append(csv, { name: "evidence.csv" });
-    archive.append(
-      "LARO case evidence export.\n\nmanifest.json lists provenance and analysis coverage.\nevidence.csv is a spreadsheet-ready index.\nfiles/ contains available source documents.\nanalysis/ contains source-linked document analyses.\n",
-      { name: "README.txt" }
-    );
-    for (const item of items) {
-      archive.append(JSON.stringify({ ...item, metadata: redactMetadata(parseMetadata(item.metadata)) }, null, 2), {
-        name: `evidence/${item.id}.json`,
-      });
-      const analysis = analysisByEvidence.get(item.id);
-      if (analysis) {
-        archive.append(analysis.result, { name: `analysis/${item.id}.json` });
-      }
-    }
-    for (const sourceFile of sourceFiles) archive.append(sourceFile.bytes, { name: sourceFile.name });
-    archive.finalize();
-  });
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -53,6 +53,8 @@ import {
   normalizePublicPathPrefix,
   publicPathPrefixMiddleware,
 } from './publicPathPrefix';
+import { consumeCaseZipDownloadTicket, createCaseZipStream } from './evidenceExport';
+import { AUDIT_ACTIONS, createAuditLog } from './audit';
 
 // ─── Environment ──────────────────────────────────────────────────────────────
 
@@ -212,6 +214,52 @@ app.get('/api/evidence-content/:id', async (req, res) => {
     res.status(status).json({
       error: status === 500 ? 'Evidence source could not be read' : (error as Error).message,
     });
+  }
+});
+
+app.get('/api/case-export/:ticket.zip', async (req, res) => {
+  let source: Awaited<ReturnType<typeof createCaseZipStream>> | null = null;
+  const abortController = new AbortController();
+  const abort = () => abortController.abort();
+  req.once('aborted', abort);
+  res.once('close', () => {
+    if (!res.writableFinished) abort();
+  });
+  try {
+    const ctx = await createContext({ req, res });
+    if (!ctx.user || ctx.authScope !== 'session') {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+    const caseId = consumeCaseZipDownloadTicket(req.params.ticket, ctx.user.id);
+    source = await createCaseZipStream(ctx.user.id, caseId, { signal: abortController.signal });
+    const fileName = encodeURIComponent(sanitizeFilename(source.filename));
+    res.setHeader('Cache-Control', 'private, no-store');
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', `attachment; filename*=UTF-8''${fileName}`);
+    const responseFinished = new Promise<void>((resolve, reject) => {
+      res.once('finish', resolve);
+      res.once('error', reject);
+    });
+    source.stream.pipe(res);
+    const result = await source.completion;
+    await responseFinished;
+    await createAuditLog({
+      userId: ctx.user.id,
+      action: AUDIT_ACTIONS.EVIDENCE_EXPORTED,
+      entityType: 'case',
+      entityId: caseId,
+      details: { format: 'zip', bytes: result.bytes, sourceFileCount: result.sourceFileCount },
+    });
+  } catch (error) {
+    source?.stream.destroy();
+    if (res.headersSent) {
+      res.destroy(error as Error);
+      return;
+    }
+    const message = error instanceof Error ? error.message : 'Evidence export failed';
+    const status = /invalid or expired/i.test(message) ? 403 : /not found/i.test(message) ? 404 : /queue is full/i.test(message) ? 429 : 500;
+    res.status(status).json({ error: status === 500 ? 'Evidence export failed' : message });
   }
 });
 

--- a/server/rateLimit.ts
+++ b/server/rateLimit.ts
@@ -112,6 +112,12 @@ export const RATE_LIMITS = {
     windowMs: 60 * 60 * 1000, // 1 hour
     message: "AI analysis limit reached. Please wait before requesting more analyses.",
   },
+
+  evidenceExport: {
+    maxRequests: 10,
+    windowMs: 5 * 60 * 1000,
+    message: "Too many evidence export requests. Please use an existing link or wait briefly.",
+  },
   
   // General API calls
   general: {

--- a/server/routers/cases.ts
+++ b/server/routers/cases.ts
@@ -169,16 +169,19 @@ export const casesRouter = router({
       };
     }),
 
-  // Phase 023 — export a case's evidence as a real ZIP package (manifest +
-  // per-item metadata + provenance hashes). Owner-scoped. Returns base64 so the
-  // renderer can save it as a .zip file.
+  // Phase 023 — issue an owner-scoped URL for the streamed evidence package.
   exportZip: protectedProcedure
     .input(z.object({ caseId: z.string() }))
     .mutation(async ({ input, ctx }) => {
+      enforceRateLimit(ctx, "evidence-export", RATE_LIMITS.evidenceExport);
       await assertCaseOwnership(input.caseId, ctx.user.id);
-      const { buildCaseZip } = await import("../evidenceExport");
-      const buf = await buildCaseZip(ctx.user.id, input.caseId);
-      return { format: "laro-case-zip/v1", filename: `case-${input.caseId}.zip`, bytes: buf.length, base64: buf.toString("base64") };
+      const { issueCaseZipDownloadTicket } = await import("../evidenceExport");
+      const ticket = issueCaseZipDownloadTicket(ctx.user.id, input.caseId);
+      return {
+        format: "laro-case-zip/v2",
+        filename: `case-${input.caseId}-evidence.zip`,
+        url: `/api/case-export/${ticket}.zip`,
+      };
     }),
 
   // Phase 023 — export the user's case list as CSV text (client-downloadable).

--- a/server/routers/evidenceExport.ts
+++ b/server/routers/evidenceExport.ts
@@ -2,7 +2,9 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { protectedProcedure, router } from "../_core/trpc";
 import { AUDIT_ACTIONS, createAuditLog } from "../audit";
-import { buildCaseCsv, buildCaseZip } from "../evidenceExport";
+import { buildCaseCsv, issueCaseZipDownloadTicket } from "../evidenceExport";
+import { assertCaseOwnership } from "../_core/authz";
+import { enforceRateLimit, RATE_LIMITS } from "../rateLimit";
 
 function encodedDownload(filename: string, mimeType: string, buffer: Buffer) {
   return {
@@ -37,15 +39,14 @@ export const evidenceExportRouter = router({
   exportZIP: protectedProcedure
     .input(z.object({ caseId: z.string().min(1) }))
     .mutation(async ({ input, ctx }) => {
-      const buffer = await buildCaseZip(ctx.user.id, input.caseId);
-      await createAuditLog({
-        userId: ctx.user.id,
-        action: AUDIT_ACTIONS.EVIDENCE_EXPORTED,
-        entityType: "case",
-        entityId: input.caseId,
-        details: { format: "zip", bytes: buffer.length },
-      });
-      return encodedDownload(`case-${input.caseId}-evidence.zip`, "application/zip", buffer);
+      enforceRateLimit(ctx, "evidence-export", RATE_LIMITS.evidenceExport);
+      await assertCaseOwnership(input.caseId, ctx.user.id);
+      const ticket = issueCaseZipDownloadTicket(ctx.user.id, input.caseId);
+      return {
+        filename: `case-${input.caseId}-evidence.zip`,
+        mimeType: "application/zip",
+        url: `/api/case-export/${ticket}.zip`,
+      };
     }),
 
   exportPDF: protectedProcedure

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,6 +16,8 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { createHash } from 'crypto';
 import path from 'path';
 import fs from 'fs';
+import { Readable, Transform } from 'stream';
+import { pipeline } from 'stream/promises';
 import { collectBoundedBytes } from './boundedBytes';
 
 const s3 = new S3Client({
@@ -138,6 +140,59 @@ export async function storageRead(key: string, options?: { maxBytes: number }): 
     }
   }
   return fs.readFileSync(full);
+}
+
+export async function storageOpenReadStream(
+  key: string,
+  options: { maxBytes: number; signal?: AbortSignal },
+): Promise<{ stream: Readable; declaredBytes: number | null; completion: Promise<void> }> {
+  if (options.signal?.aborted) throw new Error("Storage read was cancelled");
+  const safeKey = sanitizeStorageKey(key);
+  if (!safeKey) throw new Error('Storage key must contain at least one valid path segment');
+  let source: Readable;
+  let declaredBytes: number | null = null;
+  if (isS3Configured()) {
+    const response = await s3.send(
+      new GetObjectCommand({ Bucket: BUCKET, Key: safeKey }),
+      { abortSignal: options.signal },
+    );
+    if (!response.Body) throw new Error(`Storage object is empty: ${safeKey}`);
+    declaredBytes = typeof response.ContentLength === 'number' ? response.ContentLength : null;
+    if (declaredBytes !== null && declaredBytes > options.maxBytes) {
+      if (response.Body instanceof Readable) response.Body.destroy();
+      else if (typeof response.Body.transformToWebStream === 'function') {
+        void response.Body.transformToWebStream().cancel().catch(() => undefined);
+      }
+      throw new Error(`Storage object exceeds the ${options.maxBytes} byte read limit`);
+    }
+    source = response.Body instanceof Readable
+      ? response.Body
+      : Readable.from(response.Body as unknown as AsyncIterable<Uint8Array>);
+  } else {
+    const full = resolveLocalPath(safeKey);
+    if (!fs.existsSync(full)) throw new Error(`Local storage object not found: ${safeKey}`);
+    declaredBytes = fs.statSync(full).size;
+    if (declaredBytes > options.maxBytes) {
+      throw new Error(`Storage object exceeds the ${options.maxBytes} byte read limit`);
+    }
+    if (options.signal?.aborted) throw new Error("Storage read was cancelled");
+    source = fs.createReadStream(full);
+  }
+
+  let actualBytes = 0;
+  const limiter = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      actualBytes += chunk.length;
+      callback(
+        actualBytes > options.maxBytes
+          ? new Error(`Storage object exceeds the ${options.maxBytes} byte read limit`)
+          : null,
+        chunk,
+      );
+    },
+  });
+  const completion = pipeline(source, limiter, { signal: options.signal });
+  return { stream: limiter, declaredBytes, completion };
 }
 
 export async function storageDelete(key: string): Promise<void> {

--- a/src/renderer/components/EvidenceExportUI.tsx
+++ b/src/renderer/components/EvidenceExportUI.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { trpc } from "@/lib/trpc";
+import { apiBase } from "@/providers/TrpcProvider";
 
 interface EvidenceExportUIProps {
   caseId: string;
@@ -32,7 +33,7 @@ function downloadBase64(payload: DownloadPayload): void {
 }
 
 export default function EvidenceExportUI({ caseId }: EvidenceExportUIProps) {
-  const [lastExport, setLastExport] = useState<{ format: string; bytes: number } | null>(null);
+  const [lastExport, setLastExport] = useState<{ format: string; bytes?: number } | null>(null);
   const { data: formats = [], isLoading } = trpc.evidenceExport.getFormats.useQuery();
 
   const csvExport = trpc.evidenceExport.exportCSV.useMutation({
@@ -45,9 +46,14 @@ export default function EvidenceExportUI({ caseId }: EvidenceExportUIProps) {
   });
   const zipExport = trpc.evidenceExport.exportZIP.useMutation({
     onSuccess: (payload) => {
-      downloadBase64(payload);
-      setLastExport({ format: "ZIP", bytes: payload.bytes });
-      toast.success("Evidence package downloaded");
+      const link = document.createElement("a");
+      link.href = `${apiBase()}${payload.url}`;
+      link.download = payload.filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      setLastExport({ format: "ZIP" });
+      toast.success("Evidence package download started");
     },
     onError: (error) => toast.error(error.message),
   });
@@ -111,7 +117,8 @@ export default function EvidenceExportUI({ caseId }: EvidenceExportUIProps) {
         {lastExport && (
           <div className="flex items-center gap-2 border-t border-border/60 pt-4 text-sm text-muted-foreground">
             <CheckCircle2 className="h-4 w-4 text-green-500" />
-            Last download: {lastExport.format}, {(lastExport.bytes / 1024).toFixed(1)} KB
+            Last download: {lastExport.format}
+            {typeof lastExport.bytes === "number" ? `, ${(lastExport.bytes / 1024).toFixed(1)} KB` : ""}
           </div>
         )}
       </CardContent>

--- a/src/renderer/providers/TrpcProvider.tsx
+++ b/src/renderer/providers/TrpcProvider.tsx
@@ -4,7 +4,7 @@ import { httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
 import { trpc } from "@/lib/trpc";
 
-function apiBase(): string {
+export function apiBase(): string {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_API_URL) {
     return String(import.meta.env.VITE_API_URL).replace(/\/$/, "");
   }

--- a/tests/backend/evidenceScoringAndExport.test.ts
+++ b/tests/backend/evidenceScoringAndExport.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { eq } from "drizzle-orm";
-import { buildCase, buildUser } from "../factories";
+import { randomBytes } from "crypto";
+import { buildCase, buildEvidence, buildUser } from "../factories";
 import { bootTestApp, sqliteAvailable, type TestApp } from "../helpers/app";
 
 const suite = sqliteAvailable ? describe : describe.skip;
@@ -106,23 +107,145 @@ suite("evidence scoring and case export", () => {
     expect(csv).not.toContain("CASE_SCORE_OTHER");
 
     const zipDownload = await caller.evidenceExport.exportZIP({ caseId: "CASE_SCORE_OWNER" });
-    const zip = Buffer.from(zipDownload.base64, "base64");
+    expect(zipDownload.url).toMatch(/^\/api\/case-export\/[A-Za-z0-9_-]{43}\.zip$/);
+    const { createCaseZipStream } = await import("../../server/evidenceExport");
+    const streamed = await createCaseZipStream(owner.id, "CASE_SCORE_OWNER");
+    const chunks: Buffer[] = [];
+    for await (const chunk of streamed.stream) chunks.push(Buffer.from(chunk));
+    const result = await streamed.completion;
+    const zip = Buffer.concat(chunks);
     const zipDirectory = zip.toString("latin1");
     expect(zip.subarray(0, 2).toString("ascii")).toBe("PK");
     expect(zipDirectory).toContain("manifest.json");
     expect(zipDirectory).toContain("evidence.csv");
     expect(zipDirectory).toContain("analysis/");
     expect(zipDirectory).toContain("files/");
-    expect(zipDownload.bytes).toBe(zip.length);
+    expect(result.bytes).toBe(zip.length);
     const exportAudit = await caller.audit.list({
       entityType: "case",
       entityId: "CASE_SCORE_OWNER",
       action: "evidence.exported",
     });
-    expect(exportAudit).toHaveLength(2);
+    expect(exportAudit).toHaveLength(1);
 
     await expect(app.makeCaller(other).evidenceExport.exportZIP({
       caseId: "CASE_SCORE_OWNER",
     })).rejects.toThrow();
+  });
+
+  it("keeps ZIP output backpressure-bounded and rejects export queue overflow", async () => {
+    const { storagePut } = await import("../../server/storage");
+    const stored = await storagePut(
+      "evidence/CASE_SCORE_OWNER/large.bin",
+      randomBytes(4 * 1024 * 1024),
+    );
+    await app.db.insert(app.schema.evidence).values(buildEvidence({
+      id: "EVIDENCE_LARGE_EXPORT",
+      caseId: "CASE_SCORE_OWNER",
+      userId: owner.id,
+      title: "Large source",
+      type: "document",
+      fileName: "large.bin",
+      mimeType: "application/octet-stream",
+      source: "manual",
+      fileSize: String(4 * 1024 * 1024),
+      metadata: JSON.stringify({ storageKey: stored.key, contentHash: stored.sha256 }),
+    }));
+    const { createCaseZipStream } = await import("../../server/evidenceExport");
+    const drain = async (item: Awaited<ReturnType<typeof createCaseZipStream>>) => {
+      let bytes = 0;
+      for await (const chunk of item.stream) bytes += Buffer.byteLength(chunk);
+      const completed = await item.completion;
+      expect(completed.bytes).toBe(bytes);
+    };
+
+    const first = await createCaseZipStream(owner.id, "CASE_SCORE_OWNER");
+    let completed = false;
+    void first.completion.then(() => { completed = true; });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(completed).toBe(false);
+    expect(first.stream.readableLength).toBeLessThanOrEqual(128 * 1024);
+
+    const secondPromise = createCaseZipStream(owner.id, "CASE_SCORE_OWNER");
+    const thirdPromise = createCaseZipStream(owner.id, "CASE_SCORE_OWNER");
+    await expect(createCaseZipStream(owner.id, "CASE_SCORE_OWNER"))
+      .rejects.toThrow("Evidence export queue is full");
+    await drain(first);
+    await drain(await secondPromise);
+    await drain(await thirdPromise);
+  });
+
+  it("binds ZIP tickets to one user and one use", async () => {
+    const { consumeCaseZipDownloadTicket, issueCaseZipDownloadTicket } = await import("../../server/evidenceExport");
+    const attacked = issueCaseZipDownloadTicket(owner.id, "CASE_SCORE_OWNER");
+    expect(() => consumeCaseZipDownloadTicket(attacked, other.id)).toThrow("invalid or expired");
+    expect(() => consumeCaseZipDownloadTicket(attacked, owner.id)).toThrow("invalid or expired");
+
+    const valid = issueCaseZipDownloadTicket(owner.id, "CASE_SCORE_OWNER");
+    expect(consumeCaseZipDownloadTicket(valid, owner.id)).toBe("CASE_SCORE_OWNER");
+    expect(() => consumeCaseZipDownloadTicket(valid, owner.id)).toThrow("invalid or expired");
+  });
+
+  it("removes disconnected exports from the waiting queue", async () => {
+    const { createCaseZipStream } = await import("../../server/evidenceExport");
+    const active = await createCaseZipStream(owner.id, "CASE_SCORE_OWNER");
+    const controller = new AbortController();
+    const queued = createCaseZipStream(owner.id, "CASE_SCORE_OWNER", { signal: controller.signal });
+    controller.abort();
+
+    await expect(queued).rejects.toThrow("Evidence export was cancelled");
+    for await (const _chunk of active.stream) { /* drain */ }
+    await active.completion;
+  });
+
+  it("honors cancellation during immediate export admission", async () => {
+    const { createCaseZipStream } = await import("../../server/evidenceExport");
+    const controller = new AbortController();
+    const exportPromise = createCaseZipStream(owner.id, "CASE_SCORE_OWNER", {
+      signal: controller.signal,
+    });
+    controller.abort(new Error("Client disconnected during export admission"));
+
+    await expect(exportPromise).rejects.toThrow("Client disconnected during export admission");
+  });
+
+  it("rejects highly compressible generated entries by uncompressed size", async () => {
+    const evidenceId = "EVIDENCE_OVERSIZED_ANALYSIS";
+    const analysisId = "ANALYSIS_OVERSIZED_EXPORT";
+    await app.db.insert(app.schema.evidence).values(buildEvidence({
+      id: evidenceId,
+      caseId: "CASE_SCORE_OWNER",
+      userId: owner.id,
+      title: "Oversized analysis fixture",
+    }));
+    await app.db.insert(app.schema.documentAnalyses).values({
+      id: analysisId,
+      evidenceId,
+      caseId: "CASE_SCORE_OWNER",
+      userId: owner.id,
+      analysisVersion: "oversized-test",
+      contentHash: "a".repeat(64),
+      status: "complete",
+      extractionMethod: "plain_text",
+      providerStatus: "complete",
+      documentType: "legal document",
+      confidence: 100,
+      summary: "Oversized fixture",
+      result: "A".repeat(8 * 1024 * 1024 + 1),
+      analyzedChars: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const { buildCaseCsv, createCaseZipStream } = await import("../../server/evidenceExport");
+    try {
+      await expect(buildCaseCsv(owner.id, "CASE_SCORE_OWNER")).resolves.toBeInstanceOf(Buffer);
+      await expect(createCaseZipStream(owner.id, "CASE_SCORE_OWNER"))
+        .rejects.toThrow("generated content exceeds the 64 MB processing limit");
+    } finally {
+      await app.db.delete(app.schema.documentAnalyses).where(eq(app.schema.documentAnalyses.id, analysisId));
+      await app.db.delete(app.schema.evidence).where(eq(app.schema.evidence.id, evidenceId));
+    }
   });
 });

--- a/tests/backend/partials_hardening.test.ts
+++ b/tests/backend/partials_hardening.test.ts
@@ -95,8 +95,14 @@ suite('015 / 023 / 027 — evidence provenance, zip export, reminders', () => {
 
   it('023 — cases.exportZip returns a real, non-empty zip package', async () => {
     const res = await app.makeCaller(U).cases.exportZip({ caseId: 'CASE_H' });
-    expect(res.format).toBe('laro-case-zip/v1');
-    const buf = Buffer.from(res.base64, 'base64');
+    expect(res.format).toBe('laro-case-zip/v2');
+    expect(res.url).toMatch(/^\/api\/case-export\/[A-Za-z0-9_-]{43}\.zip$/);
+    const { createCaseZipStream } = await import('../../server/evidenceExport');
+    const streamed = await createCaseZipStream(U.id, 'CASE_H');
+    const chunks: Buffer[] = [];
+    for await (const chunk of streamed.stream) chunks.push(Buffer.from(chunk));
+    await streamed.completion;
+    const buf = Buffer.concat(chunks);
     expect(buf.length).toBeGreaterThan(0);
     expect(buf.slice(0, 2).toString('latin1')).toBe('PK'); // ZIP magic bytes
   });


### PR DESCRIPTION
## Summary
- stream evidence ZIP downloads directly instead of retaining archives and base64 copies in memory
- cap evidence counts, generated entries, source files, aggregate bytes, archive output, runtime, concurrency, queues, and download tickets
- propagate client cancellation through database preflight, local/S3 reads, archive generation, and HTTP delivery
- keep CSV exports independent from ZIP analysis budgets and preserve both current and legacy export routes

## Verification
- `npm.cmd run gate` (90 test files, 531 tests)
- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npx.cmd vitest run tests/backend/evidenceScoringAndExport.test.ts --reporter=dot` (7 tests)
- broader export/security/storage set (76 tests)
- independent P1/P2 review: no remaining findings, merge-ready