### PR TITLE
Scope Flask identifier lookup to case owner

### DIFF
--- a/app.py
+++ b/app.py
@@ -1756,6 +1756,7 @@ def lookup_ledger_case_identifier():
         return jsonify({'error': 'identifier query parameter is required'}), 400
     match = legal_ledger.lookup_case_identifier(
         value,
+        external_user_id=_ledger_actor(),
         identifier_type=request.args.get('type') or request.args.get('identifier_type'),
         source_party=request.args.get('source_party'),
     )

--- a/legal_ledger.py
+++ b/legal_ledger.py
@@ -1704,25 +1704,36 @@ class LegalLedger:
     def lookup_case_identifier(
         self,
         identifier_value: str,
+        *,
+        external_user_id: Any,
         identifier_type: Optional[str] = None,
         source_party: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         value = str(identifier_value or "").strip()
-        if not value:
+        owner = str(external_user_id or "").strip()
+        if not value or not owner:
             return None
         with self.session_scope() as session:
-            query = session.query(CaseIdentifier).filter_by(identifier_value=value)
+            query = (
+                session.query(CaseIdentifier, LegalCase)
+                .join(LegalCase, CaseIdentifier.case_id == LegalCase.id)
+                .join(LedgerUser, LegalCase.user_id == LedgerUser.id)
+                .filter(
+                    CaseIdentifier.identifier_value == value,
+                    LedgerUser.external_user_id == owner,
+                )
+            )
             if identifier_type:
-                query = query.filter_by(identifier_type=str(identifier_type).strip())
+                query = query.filter(CaseIdentifier.identifier_type == str(identifier_type).strip())
             if source_party:
-                query = query.filter_by(source_party=str(source_party).strip())
-            identifier = query.order_by(CaseIdentifier.updated_at.desc(), CaseIdentifier.id.desc()).first()
-            if not identifier:
+                query = query.filter(CaseIdentifier.source_party == str(source_party).strip())
+            match = query.order_by(CaseIdentifier.updated_at.desc(), CaseIdentifier.id.desc()).first()
+            if not match:
                 return None
-            case = session.get(LegalCase, identifier.case_id)
+            identifier, case = match
             return {
                 "identifier": self._serialize_identifier(identifier),
-                "case": self._case_detail(session, case) if case else None,
+                "case": self._case_detail(session, case),
             }
 
     def _create_document_record(self, session, case_id: int, data: Dict[str, Any]) -> CaseDocument:

--- a/test_legal_ledger.py
+++ b/test_legal_ledger.py
@@ -558,7 +558,11 @@ class TestLegalLedgerService(unittest.TestCase):
         self.assertEqual(duplicate["id"], added["id"])
         self.assertEqual(duplicate["source_uri"], "gmail://message/123")
 
-        match = self.ledger.lookup_case_identifier("RBGEL-24-123", identifier_type="court_reference")
+        match = self.ledger.lookup_case_identifier(
+            "RBGEL-24-123",
+            external_user_id="robert",
+            identifier_type="court_reference",
+        )
         self.assertEqual(match["case"]["case_id"], case["case_id"])
         self.assertEqual(match["identifier"]["source_party"], "Rechtbank Gelderland")
 
@@ -1214,6 +1218,37 @@ class TestLegalLedgerApi(unittest.TestCase):
     def setUp(self):
         token = self.app_module.auth_system._create_session("ledger@example.com", "user")
         self.headers = {"Authorization": f"Bearer {token}"}
+
+    def test_identifier_lookup_is_scoped_to_authenticated_owner(self):
+        victim_token = self.app_module.auth_system._create_session("identifier-owner@example.com", "user")
+        victim_headers = {"Authorization": f"Bearer {victim_token}"}
+        created = self.client.post("/api/cases", json={
+            "title": "Private identifier case",
+            "description": "Must not be discoverable by another account.",
+        }, headers=victim_headers)
+        self.assertEqual(created.status_code, 201)
+        case_id = created.get_json()["case_id"]
+        identifier_value = "PRIVATE-IDENTIFIER-2026-001"
+        identifier = self.client.post(f"/api/cases/{case_id}/identifiers", json={
+            "identifier_type": "court_reference",
+            "identifier_value": identifier_value,
+            "source_party": "Rechtbank",
+        }, headers=victim_headers)
+        self.assertEqual(identifier.status_code, 201)
+
+        denied = self.client.get(
+            f"/api/case-identifiers/lookup?identifier={identifier_value}",
+            headers=self.headers,
+        )
+        self.assertEqual(denied.status_code, 404)
+        self.assertEqual(denied.get_json(), {"error": "Case identifier not found"})
+
+        allowed = self.client.get(
+            f"/api/case-identifiers/lookup?identifier={identifier_value}",
+            headers=victim_headers,
+        )
+        self.assertEqual(allowed.status_code, 200)
+        self.assertEqual(allowed.get_json()["case"]["case_id"], case_id)
 
     def test_live_api_has_no_demo_state_stores(self):
         for attribute in (


### PR DESCRIPTION
## Summary
- require an external user identity for legacy Flask case-identifier lookups
- join identifiers through their owning case and ledger user before selecting a match
- pass the authenticated ledger actor from the API route
- return the same non-disclosing 404 for missing and cross-user identifiers
- add two-session API coverage proving owner access and attacker denial

## Verification
- `python -m unittest test_legal_ledger test_authentication` (70 tests)
- focused service, owner workflow, and cross-user API tests (3 tests)
- `npm.cmd run gate` (92 test files, 543 tests)
- typechecks, lint, dependency audits, accessibility/build budgets, and recovery drills
- independent P1/P2 review: no findings, merge-ready