### PR TITLE
Preserve S3 evidence in recovery sets

### DIFF
--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -23,7 +23,7 @@ only after every member is complete:
   `laro-secrets.json` exists beside `DATABASE_URL`;
 - `<backup>.files/`: every database-referenced evidence object from local
   managed storage or S3, with per-file size and SHA-256 inventory in the
-  manifest.
+  manifest; S3 entries also retain their content type.
 
 The manifest is renamed into place last and acts as the completion marker. LARO
 refuses to overwrite an existing set. For a standalone server whose key comes
@@ -120,11 +120,12 @@ remains beside each live path with a `.bak-<timestamp>` suffix.
 An S3-backed version-3 set restores only when the active bucket and region
 exactly match the manifest. Before writing the backup bytes, LARO snapshots all
 objects referenced by the live database into a timestamped local previous-state
-directory. Every restored write must return the manifest SHA-256. A failed write
-is then read back from S3 and rehashed before restore continues. A failed write,
-read-back mismatch, or database replacement restores previous objects and
-removes newly introduced keys; incomplete rollback is reported and the
-previous-state directory is kept for operator recovery.
+directory plus its own manifest. Every restored write retains the recorded
+content type and must return the manifest SHA-256. It is then read back from S3;
+bytes, hash, size, and content type must all match before restore continues. A
+failed write, read-back mismatch, or database replacement restores previous
+objects and removes newly introduced keys; incomplete rollback is reported and
+the previous-state directory and manifest are kept for operator recovery.
 
 A legacy database-only restore is blocked by default. After separately proving
 that the correct historical key is installed, an operator can accept that risk

--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -21,8 +21,9 @@ only after every member is complete:
 - `<backup>.manifest.json`: database size/hash and encryption compatibility;
 - `<backup>.secrets.json`: the matching desktop keys, when a valid
   `laro-secrets.json` exists beside `DATABASE_URL`;
-- `<backup>.files/`: every file from local managed storage, with per-file size
-  and SHA-256 inventory in the manifest.
+- `<backup>.files/`: every database-referenced evidence object from local
+  managed storage or S3, with per-file size and SHA-256 inventory in the
+  manifest.
 
 The manifest is renamed into place last and acts as the completion marker. LARO
 refuses to overwrite an existing set. For a standalone server whose key comes
@@ -36,9 +37,15 @@ root.
 For local storage, LARO copies and hashes every regular file, rejects symbolic
 links and unsafe paths, verifies that every database-managed storage key exists,
 then rescans the source after the SQLite snapshot. Any addition, removal, or byte
-change aborts publication. When `AWS_S3_BUCKET` is configured, remote objects are
-not copied; the manifest records the bucket, region, and database-derived key
-inventory. S3 versioning/replication remains an external operational requirement.
+change aborts publication. When `AWS_S3_BUCKET` is configured, LARO reads every
+database-referenced object through the bounded storage reader and writes the raw
+bytes into `<backup>.files/`. Missing objects, objects above 64 MB, more than
+100,000 managed objects, a set above 100 GB, unsafe keys, or any post-copy hash
+mismatch abort publication. The manifest binds the snapshot to its source bucket
+and region. Original S3 keys remain in the manifest while snapshot files use
+portable SHA-256 key names, including on Windows. S3 versioning and replication
+remain recommended defense in depth,
+but version-3 recovery no longer depends on the live object remaining present.
 
 The default destination is a timestamped file under `db-backups` beside the live
 database. Keep every set member together on access-controlled or encrypted
@@ -89,9 +96,10 @@ npm run db:validate -- C:\Backups\laro.sqlite
 
 Validation is read-only. For a backup set it verifies the manifest, filenames,
 sizes, SHA-256 hashes, SQLite integrity, foreign keys, core schema, encryption
-key compatibility, and local-file or S3-key coverage. A database-only backup is
-labelled legacy because token and file recovery cannot be proven. A version-1
-backup set can still be inspected, but is labelled as missing storage coverage.
+key compatibility, and complete local or bundled-S3 byte coverage. A
+database-only backup is labelled legacy because token and file recovery cannot
+be proven. Version-1 sets and version-2 S3 inventory-only sets can still be
+inspected, but are labelled as missing complete storage coverage.
 
 ## Electron Restore
 
@@ -109,8 +117,14 @@ then restores SQLite. A database failure independently rolls back storage and
 keys; an incomplete rollback is reported as a maintenance error. Previous state
 remains beside each live path with a `.bak-<timestamp>` suffix.
 
-An S3-backed set restores only when the active bucket and region exactly match
-the manifest. It never claims to have copied or restored remote objects.
+An S3-backed version-3 set restores only when the active bucket and region
+exactly match the manifest. Before writing the backup bytes, LARO snapshots all
+objects referenced by the live database into a timestamped local previous-state
+directory. Every restored write must return the manifest SHA-256. A failed write
+is then read back from S3 and rehashed before restore continues. A failed write,
+read-back mismatch, or database replacement restores previous objects and
+removes newly introduced keys; incomplete rollback is reported and the
+previous-state directory is kept for operator recovery.
 
 A legacy database-only restore is blocked by default. After separately proving
 that the correct historical key is installed, an operator can accept that risk
@@ -120,8 +134,9 @@ explicitly:
 npm run db:restore -- C:\Backups\legacy.sqlite --allow-legacy
 ```
 
-A version-1 set without evidence coverage is also blocked. Only after separately
-restoring the matching local evidence may an operator use:
+Version-1 sets and version-2 S3 inventory-only sets without complete evidence
+coverage are also blocked. Only after separately restoring and verifying the
+matching evidence may an operator use:
 
 ```powershell
 npm run db:restore -- C:\Backups\v1.sqlite --allow-missing-storage

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -25,7 +25,7 @@ async function main() {
   if (commandOrDest === '--restore') {
     if (!file) throw new Error('Usage: npm run db:restore -- <backup.sqlite>');
     if (fs.existsSync(backupSetManifestPath(file))) {
-      const result = restoreBackupSet(file, {
+      const result = await restoreBackupSet(file, {
         desktopSecretsPath,
         localStoragePath,
         allowMissingStorage: parsed.allowMissingStorage,
@@ -54,15 +54,15 @@ async function main() {
     if (fs.existsSync(backupSetManifestPath(file))) {
       const result = validateBackupSet(file);
       if (!result.valid) throw new Error(`Invalid backup set: ${result.reason}`);
-      if (result.storageCoverage === 'legacy-missing') {
+      if (result.storageCoverage === 'legacy-missing' || result.storageCoverage === 'legacy-external-s3') {
         console.warn(
           `[Validate] Version-1 backup set is structurally valid with ${result.tables?.length || 0} tables, ` +
-            'but local evidence coverage is not proven.',
+            'but complete evidence coverage is not proven.',
         );
       } else {
         console.log(
           `[Validate] Valid backup set with ${result.tables?.length || 0} tables and ` +
-            `${result.storageCoverage === 'complete-local' ? 'complete local evidence' : 'external S3 inventory'}.`,
+            `${result.storageCoverage === 'complete-local' ? 'complete local evidence' : 'complete bundled S3 evidence'}.`,
         );
       }
       return;
@@ -86,7 +86,7 @@ async function main() {
   console.log(`[Backup] Wrote ${result.bytes} database bytes to ${result.databasePath}`);
   console.log(`[Backup] Recovery manifest: ${result.manifestPath}`);
   console.log(`[Backup] Desktop secrets: ${result.secretsPath || 'external environment; retain JWT_SECRET separately'}`);
-  console.log(`[Backup] Local evidence: ${result.storagePath || 'external S3 inventory recorded in manifest'}`);
+  console.log(`[Backup] Evidence snapshot: ${result.storagePath || 'not bundled'}`);
 }
 
 main().catch((error) => {

--- a/scripts/recovery-drill.ts
+++ b/scripts/recovery-drill.ts
@@ -57,7 +57,7 @@ async function main() {
   }, null, 2), { mode: 0o600 });
   writeFileSync(evidencePath, 'changed evidence bytes', 'utf8');
 
-  const restored = backup.restoreBackupSet(backupPath, { desktopSecretsPath: secretsPath });
+  const restored = await backup.restoreBackupSet(backupPath, { desktopSecretsPath: secretsPath });
   const reopened = await getDb();
   const row = (reopened as any).$client.prepare('SELECT id FROM users WHERE id = ?').get(marker);
   if (!row) throw new Error('Round-trip restore did not recover the marker row');

--- a/server/backupSet.ts
+++ b/server/backupSet.ts
@@ -65,7 +65,10 @@ export interface CreateBackupSetOptions {
   desktopSecretsPath?: string;
   externalJwtSecret?: string;
   localStoragePath?: string;
-  externalStorageRead?: (key: string, options: { maxBytes: number }) => Promise<Buffer>;
+  externalStorageRead?: (
+    key: string,
+    options: { maxBytes: number },
+  ) => Promise<{ body: Buffer; contentType: string }>;
 }
 
 export interface ValidateBackupSetOptions {
@@ -84,8 +87,11 @@ export interface RestoreBackupSetOptions extends ValidateBackupSetOptions {
   desktopSecretsPath?: string;
   localStoragePath?: string;
   allowMissingStorage?: boolean;
-  externalStorageRead?: (key: string, options: { maxBytes: number }) => Promise<Buffer>;
-  externalStoragePut?: (key: string, body: Buffer) => Promise<{ sha256: string }>;
+  externalStorageRead?: (
+    key: string,
+    options: { maxBytes: number },
+  ) => Promise<{ body: Buffer; contentType: string }>;
+  externalStoragePut?: (key: string, body: Buffer, contentType: string) => Promise<{ sha256: string }>;
   externalStorageDelete?: (key: string) => Promise<void>;
 }
 
@@ -309,8 +315,8 @@ export async function createBackupSet(
       }
     } else {
       const readExternalObject = options.externalStorageRead || (async (key, readOptions) => {
-        const { storageRead } = await import("./storage");
-        return storageRead(key, readOptions);
+        const { storageReadForBackup } = await import("./storage");
+        return storageReadForBackup(key, readOptions);
       });
       storage = await createS3StorageSnapshot(
         temporaryDatabase,
@@ -525,12 +531,12 @@ async function installS3StorageSnapshot(
   options: RestoreBackupSetOptions,
 ): Promise<{ previous: string; rollback: () => Promise<void> }> {
   const readObject = options.externalStorageRead || (async (key, readOptions) => {
-    const { storageRead } = await import("./storage");
-    return storageRead(key, readOptions);
+    const { storageReadForBackup } = await import("./storage");
+    return storageReadForBackup(key, readOptions);
   });
-  const putObject = options.externalStoragePut || (async (key, body) => {
+  const putObject = options.externalStoragePut || (async (key, body, contentType) => {
     const { storagePut } = await import("./storage");
-    return storagePut(key, body);
+    return storagePut(key, body, contentType);
   });
   const deleteObject = options.externalStorageDelete || (async (key) => {
     const { storageDelete } = await import("./storage");
@@ -538,6 +544,7 @@ async function installS3StorageSnapshot(
   });
   const backupStoragePath = backupSetStoragePath(backupDatabasePath);
   const previousPath = `${currentDatabasePath()}.s3-files.bak-${Date.now()}`;
+  const previousManifestPath = `${previousPath}.manifest.json`;
   const previousInventoryDatabase = `${previousPath}.inventory.sqlite`;
   let previousManifest: BundledS3StorageManifest;
   try {
@@ -550,8 +557,14 @@ async function installS3StorageSnapshot(
       manifest.region,
       readObject,
     );
+    fs.writeFileSync(previousManifestPath, JSON.stringify(previousManifest, null, 2), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
   } catch (error) {
     removeIfPresent(previousPath);
+    removeIfPresent(previousManifestPath);
     throw error;
   } finally {
     removeIfPresent(previousInventoryDatabase);
@@ -571,13 +584,17 @@ async function installS3StorageSnapshot(
         throw new Error(`Bundled S3 evidence has an invalid restore size: ${entry.key}`);
       }
       if (trackWrites) written.add(entry.key);
-      const stored = await putObject(entry.key, body);
+      const stored = await putObject(entry.key, body, entry.contentType);
       if (stored.sha256 !== entry.sha256) {
         throw new Error(`Restored S3 evidence hash does not match its manifest: ${entry.key}`);
       }
       const readBack = await readObject(entry.key, { maxBytes: MAX_BACKUP_STORAGE_OBJECT_BYTES });
-      const readBackHash = crypto.createHash("sha256").update(readBack).digest("hex");
-      if (readBack.length !== entry.bytes || readBackHash !== entry.sha256) {
+      const readBackHash = crypto.createHash("sha256").update(readBack.body).digest("hex");
+      if (
+        readBack.body.length !== entry.bytes ||
+        readBackHash !== entry.sha256 ||
+        readBack.contentType !== entry.contentType
+      ) {
         throw new Error(`Restored S3 evidence read-back hash does not match its manifest: ${entry.key}`);
       }
     }
@@ -594,7 +611,10 @@ async function installS3StorageSnapshot(
     } catch (error) {
       errors.push(error);
     }
-    if (errors.length === 0) removeIfPresent(previousPath);
+    if (errors.length === 0) {
+      removeIfPresent(previousPath);
+      removeIfPresent(previousManifestPath);
+    }
     if (errors.length > 0) {
       throw new AggregateError(errors, "Previous S3 evidence could not be fully reinstated.");
     }

--- a/server/backupSet.ts
+++ b/server/backupSet.ts
@@ -1,21 +1,30 @@
 import crypto from "crypto";
 import fs from "fs";
 import path from "path";
-import { backupDatabase, restoreDatabase, validateBackup } from "./backup";
+import {
+  backupDatabase,
+  cleanupBackupDatabaseSidecars,
+  restoreDatabase,
+  validateBackup,
+} from "./backup";
 import {
   assertLocalStorageUnchanged,
   backupSetStoragePath,
-  createExternalS3Manifest,
   createLocalStorageSnapshot,
+  createS3StorageSnapshot,
   installLocalStorageSnapshot,
   isBackupStorageManifest,
+  MAX_BACKUP_STORAGE_OBJECT_BYTES,
+  readStorageSnapshotFile,
   validateBackupStorage,
   type BackupStorageManifest,
   type BundledLocalStorageManifest,
+  type BundledS3StorageManifest,
 } from "./backupStorage";
 
 const FORMAT = "laro-backup-set";
-const VERSION = 2;
+const VERSION = 3;
+const INVENTORY_ONLY_VERSION = 2;
 const LEGACY_VERSION = 1;
 const SECRET_PATTERN = /^[a-f0-9]{64}$/;
 const COMPATIBILITY_CONTEXT = "LARO backup token-encryption compatibility v1";
@@ -45,7 +54,7 @@ type EncryptionManifestEntry =
 
 export interface BackupSetManifest {
   format: typeof FORMAT;
-  version: typeof VERSION | typeof LEGACY_VERSION;
+  version: typeof VERSION | typeof INVENTORY_ONLY_VERSION | typeof LEGACY_VERSION;
   createdAt: string;
   database: DatabaseManifestEntry;
   encryption: EncryptionManifestEntry;
@@ -56,6 +65,7 @@ export interface CreateBackupSetOptions {
   desktopSecretsPath?: string;
   externalJwtSecret?: string;
   localStoragePath?: string;
+  externalStorageRead?: (key: string, options: { maxBytes: number }) => Promise<Buffer>;
 }
 
 export interface ValidateBackupSetOptions {
@@ -67,13 +77,16 @@ export interface BackupSetValidation {
   reason?: string;
   manifest?: BackupSetManifest;
   tables?: string[];
-  storageCoverage?: "complete-local" | "external-s3" | "legacy-missing";
+  storageCoverage?: "complete-local" | "complete-s3" | "legacy-external-s3" | "legacy-missing";
 }
 
 export interface RestoreBackupSetOptions extends ValidateBackupSetOptions {
   desktopSecretsPath?: string;
   localStoragePath?: string;
   allowMissingStorage?: boolean;
+  externalStorageRead?: (key: string, options: { maxBytes: number }) => Promise<Buffer>;
+  externalStoragePut?: (key: string, body: Buffer) => Promise<{ sha256: string }>;
+  externalStorageDelete?: (key: string) => Promise<void>;
 }
 
 export interface RestoreBackupSetResult {
@@ -141,7 +154,7 @@ function parseManifest(manifestPath: string): BackupSetManifest {
   const encryption = candidate.encryption as Record<string, unknown> | undefined;
   const baseValid =
     candidate.format === FORMAT &&
-    (candidate.version === VERSION || candidate.version === LEGACY_VERSION) &&
+    (candidate.version === VERSION || candidate.version === INVENTORY_ONLY_VERSION || candidate.version === LEGACY_VERSION) &&
     typeof candidate.createdAt === "string" &&
     !Number.isNaN(Date.parse(candidate.createdAt)) &&
     database &&
@@ -160,8 +173,14 @@ function parseManifest(manifestPath: string): BackupSetManifest {
   } else if (encryption.mode !== "external-environment") {
     throw new Error("Backup-set encryption mode is unsupported.");
   }
-  if (candidate.version === VERSION && !isBackupStorageManifest(candidate.storage)) {
+  if (
+    (candidate.version === VERSION || candidate.version === INVENTORY_ONLY_VERSION) &&
+    !isBackupStorageManifest(candidate.storage)
+  ) {
     throw new Error("Backup-set storage metadata is invalid.");
+  }
+  if (candidate.version === VERSION && (candidate.storage as BackupStorageManifest).mode === "external-s3") {
+    throw new Error("Version-3 backup sets must bundle S3 evidence bytes.");
   }
   return parsed as BackupSetManifest;
 }
@@ -289,11 +308,27 @@ export async function createBackupSet(
         throw new Error(`Local evidence backup verification failed: ${storageValidation.reason}`);
       }
     } else {
-      storage = createExternalS3Manifest(
+      const readExternalObject = options.externalStorageRead || (async (key, readOptions) => {
+        const { storageRead } = await import("./storage");
+        return storageRead(key, readOptions);
+      });
+      storage = await createS3StorageSnapshot(
         temporaryDatabase,
+        temporaryStorage,
+        path.basename(storagePath),
         externalBucket,
         process.env.AWS_S3_REGION || "eu-west-1",
+        readExternalObject,
       );
+      const storageValidation = validateBackupStorage(
+        temporaryDatabase,
+        temporaryStorage,
+        storage,
+        path.basename(storagePath),
+      );
+      if (!storageValidation.valid) {
+        throw new Error(`S3 evidence backup verification failed: ${storageValidation.reason}`);
+      }
     }
 
     let encryption: EncryptionManifestEntry;
@@ -329,7 +364,7 @@ export async function createBackupSet(
       mode: 0o600,
     });
 
-    if (storage!.mode === "bundled-local") {
+    if (storage!.mode === "bundled-local" || storage!.mode === "bundled-s3") {
       fs.renameSync(temporaryStorage, storagePath);
       published.push(storagePath);
     }
@@ -346,7 +381,7 @@ export async function createBackupSet(
       databasePath: destination,
       manifestPath,
       secretsPath: secretSource.mode === "desktop" ? secretsPath : null,
-      storagePath: storage!.mode === "bundled-local" ? storagePath : null,
+      storagePath: storage!.mode === "bundled-local" || storage!.mode === "bundled-s3" ? storagePath : null,
       bytes: backup.bytes,
     };
   } catch (error) {
@@ -429,7 +464,11 @@ export function validateBackupSet(
       valid: true,
       manifest,
       tables: databaseValidation.tables,
-      storageCoverage: manifest.storage!.mode === "bundled-local" ? "complete-local" : "external-s3",
+      storageCoverage: manifest.storage!.mode === "bundled-local"
+        ? "complete-local"
+        : manifest.storage!.mode === "bundled-s3"
+          ? "complete-s3"
+          : "legacy-external-s3",
     };
   } catch (error) {
     return { valid: false, reason: error instanceof Error ? error.message : String(error) };
@@ -480,18 +519,118 @@ function installBundledSecrets(
   };
 }
 
-export function restoreBackupSet(
+async function installS3StorageSnapshot(
+  backupDatabasePath: string,
+  manifest: BundledS3StorageManifest,
+  options: RestoreBackupSetOptions,
+): Promise<{ previous: string; rollback: () => Promise<void> }> {
+  const readObject = options.externalStorageRead || (async (key, readOptions) => {
+    const { storageRead } = await import("./storage");
+    return storageRead(key, readOptions);
+  });
+  const putObject = options.externalStoragePut || (async (key, body) => {
+    const { storagePut } = await import("./storage");
+    return storagePut(key, body);
+  });
+  const deleteObject = options.externalStorageDelete || (async (key) => {
+    const { storageDelete } = await import("./storage");
+    return storageDelete(key);
+  });
+  const backupStoragePath = backupSetStoragePath(backupDatabasePath);
+  const previousPath = `${currentDatabasePath()}.s3-files.bak-${Date.now()}`;
+  const previousInventoryDatabase = `${previousPath}.inventory.sqlite`;
+  let previousManifest: BundledS3StorageManifest;
+  try {
+    await backupDatabase(previousInventoryDatabase);
+    previousManifest = await createS3StorageSnapshot(
+      previousInventoryDatabase,
+      previousPath,
+      path.basename(previousPath),
+      manifest.bucket,
+      manifest.region,
+      readObject,
+    );
+  } catch (error) {
+    removeIfPresent(previousPath);
+    throw error;
+  } finally {
+    removeIfPresent(previousInventoryDatabase);
+    cleanupBackupDatabaseSidecars(previousInventoryDatabase);
+  }
+
+  const previousKeys = new Set(previousManifest.objects.map((entry) => entry.key));
+  const written = new Set<string>();
+  const writeFiles = async (
+    snapshotPath: string,
+    objects: BundledS3StorageManifest["objects"],
+    trackWrites: boolean,
+  ): Promise<void> => {
+    for (const entry of objects) {
+      const body = readStorageSnapshotFile(snapshotPath, entry.file);
+      if (body.length > MAX_BACKUP_STORAGE_OBJECT_BYTES || body.length !== entry.bytes) {
+        throw new Error(`Bundled S3 evidence has an invalid restore size: ${entry.key}`);
+      }
+      if (trackWrites) written.add(entry.key);
+      const stored = await putObject(entry.key, body);
+      if (stored.sha256 !== entry.sha256) {
+        throw new Error(`Restored S3 evidence hash does not match its manifest: ${entry.key}`);
+      }
+      const readBack = await readObject(entry.key, { maxBytes: MAX_BACKUP_STORAGE_OBJECT_BYTES });
+      const readBackHash = crypto.createHash("sha256").update(readBack).digest("hex");
+      if (readBack.length !== entry.bytes || readBackHash !== entry.sha256) {
+        throw new Error(`Restored S3 evidence read-back hash does not match its manifest: ${entry.key}`);
+      }
+    }
+  };
+
+  const rollback = async (): Promise<void> => {
+    const errors: unknown[] = [];
+    for (const key of written) {
+      if (previousKeys.has(key)) continue;
+      try { await deleteObject(key); } catch (error) { errors.push(error); }
+    }
+    try {
+      await writeFiles(previousPath, previousManifest.objects, false);
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length === 0) removeIfPresent(previousPath);
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Previous S3 evidence could not be fully reinstated.");
+    }
+  };
+
+  try {
+    await writeFiles(backupStoragePath, manifest.objects, true);
+    return { previous: previousPath, rollback };
+  } catch (error) {
+    try {
+      await rollback();
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "S3 evidence restore failed and the previous objects could not be fully reinstated.",
+      );
+    }
+    throw error;
+  }
+}
+
+export async function restoreBackupSet(
   databaseBackupPath: string,
   options: RestoreBackupSetOptions = {},
-): RestoreBackupSetResult {
+): Promise<RestoreBackupSetResult> {
   const databasePath = path.resolve(databaseBackupPath);
   const validation = validateBackupSet(databasePath, options);
   if (!validation.valid || !validation.manifest) {
     throw new Error(`Refusing to restore backup set: ${validation.reason || "validation failed"}`);
   }
-  if (validation.manifest.version === LEGACY_VERSION && !options.allowMissingStorage) {
+  if (
+    (validation.manifest.version === LEGACY_VERSION || validation.manifest.storage?.mode === "external-s3") &&
+    !options.allowMissingStorage
+  ) {
     throw new Error(
-      "Refusing to restore a version-1 backup set because local evidence coverage is not proven. " +
+      "Refusing to restore an inventory-only backup set because evidence coverage is not proven. " +
         "Restore the matching storage separately or use an explicit missing-storage override.",
     );
   }
@@ -523,7 +662,10 @@ export function restoreBackupSet(
     }
   }
 
-  if (validation.manifest.storage?.mode === "external-s3") {
+  if (
+    validation.manifest.storage?.mode === "external-s3" ||
+    validation.manifest.storage?.mode === "bundled-s3"
+  ) {
     const activeBucket = (process.env.AWS_S3_BUCKET || "").trim();
     const activeRegion = process.env.AWS_S3_REGION || "eu-west-1";
     if (
@@ -538,6 +680,7 @@ export function restoreBackupSet(
 
   let secretInstall: { previous: string | null; rollback: () => void } | null = null;
   let storageInstall: { previous: string | null; rollback: () => void } | null = null;
+  let s3Install: { previous: string; rollback: () => Promise<void> } | null = null;
 
   try {
     if (validation.manifest.encryption.mode === "bundled-desktop-secret") {
@@ -559,6 +702,13 @@ export function restoreBackupSet(
         validation.manifest.storage.files,
       );
     }
+    if (validation.manifest.storage?.mode === "bundled-s3") {
+      s3Install = await installS3StorageSnapshot(
+        databasePath,
+        validation.manifest.storage,
+        options,
+      );
+    }
     const restored = restoreDatabase(databasePath, {
       bytes: validation.manifest.database.bytes,
       sha256: validation.manifest.database.sha256,
@@ -567,10 +717,15 @@ export function restoreBackupSet(
       restored: true,
       backupOfPreviousDatabase: restored.backupOfPrevious,
       backupOfPreviousSecrets: secretInstall?.previous || null,
-      backupOfPreviousStorage: storageInstall?.previous || null,
+      backupOfPreviousStorage: storageInstall?.previous || s3Install?.previous || null,
     };
   } catch (error) {
     const rollbackErrors: unknown[] = [];
+    try {
+      if (s3Install) await s3Install.rollback();
+    } catch (rollbackError) {
+      rollbackErrors.push(rollbackError);
+    }
     try {
       storageInstall?.rollback();
     } catch (rollbackError) {

--- a/server/backupStorage.ts
+++ b/server/backupStorage.ts
@@ -40,6 +40,7 @@ export interface BundledS3StorageManifest {
     file: string;
     bytes: number;
     sha256: string;
+    contentType: string;
   }>;
 }
 
@@ -87,6 +88,8 @@ export function isBackupStorageManifest(value: unknown): value is BackupStorageM
         typeof entry.file !== "string" || !isSafeRelativePath(entry.file) ||
         !Number.isSafeInteger(entry.bytes) || Number(entry.bytes) < 0 ||
         !isHexDigest(entry.sha256) ||
+        typeof entry.contentType !== "string" || !entry.contentType ||
+        entry.contentType.length > 255 || /[\x00-\x1f\x7f]/.test(entry.contentType) ||
         keys.has(entry.key) || files.has(entry.file)
       ) return false;
       keys.add(entry.key);
@@ -261,7 +264,10 @@ export async function createS3StorageSnapshot(
   publishedDirectoryName: string,
   bucket: string,
   region: string,
-  readObject: (key: string, options: { maxBytes: number }) => Promise<Buffer>,
+  readObject: (
+    key: string,
+    options: { maxBytes: number },
+  ) => Promise<{ body: Buffer; contentType: string }>,
 ): Promise<BundledS3StorageManifest> {
   const keys = managedStorageKeys(databasePath);
   if (keys.length > MAX_BACKUP_STORAGE_FILES) {
@@ -272,8 +278,13 @@ export async function createS3StorageSnapshot(
   let totalBytes = 0;
   const objects: BundledS3StorageManifest["objects"] = [];
   for (const key of keys) {
-    const body = await readObject(key, { maxBytes: MAX_BACKUP_STORAGE_OBJECT_BYTES });
+    const snapshot = await readObject(key, { maxBytes: MAX_BACKUP_STORAGE_OBJECT_BYTES });
+    const body = snapshot?.body;
     if (!Buffer.isBuffer(body)) throw new Error(`S3 evidence reader returned invalid bytes for: ${key}`);
+    const contentType = snapshot.contentType?.trim() || "application/octet-stream";
+    if (contentType.length > 255 || /[\x00-\x1f\x7f]/.test(contentType)) {
+      throw new Error(`S3 evidence has an invalid content type: ${key}`);
+    }
     totalBytes += body.length;
     if (totalBytes > MAX_BACKUP_STORAGE_TOTAL_BYTES) {
       throw new Error("S3 evidence snapshot exceeds the 100 GB backup-set limit.");
@@ -287,6 +298,7 @@ export async function createS3StorageSnapshot(
       file,
       bytes: body.length,
       sha256: crypto.createHash("sha256").update(body).digest("hex"),
+      contentType,
     });
   }
   const files = listStorageFiles(snapshotRoot);

--- a/server/backupStorage.ts
+++ b/server/backupStorage.ts
@@ -28,7 +28,29 @@ export interface ExternalS3StorageManifest {
   managedKeysSha256: string;
 }
 
-export type BackupStorageManifest = BundledLocalStorageManifest | ExternalS3StorageManifest;
+export interface BundledS3StorageManifest {
+  mode: "bundled-s3";
+  bucket: string;
+  region: string;
+  directory: string;
+  fileCount: number;
+  totalBytes: number;
+  objects: Array<{
+    key: string;
+    file: string;
+    bytes: number;
+    sha256: string;
+  }>;
+}
+
+export type BackupStorageManifest =
+  | BundledLocalStorageManifest
+  | BundledS3StorageManifest
+  | ExternalS3StorageManifest;
+
+export const MAX_BACKUP_STORAGE_OBJECT_BYTES = 64 * 1024 * 1024;
+const MAX_BACKUP_STORAGE_FILES = 100_000;
+const MAX_BACKUP_STORAGE_TOTAL_BYTES = 100 * 1024 * 1024 * 1024;
 
 function isHexDigest(value: unknown): value is string {
   return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
@@ -44,6 +66,33 @@ export function isBackupStorageManifest(value: unknown): value is BackupStorageM
       Number.isSafeInteger(candidate.managedKeyCount) && Number(candidate.managedKeyCount) >= 0 &&
       isHexDigest(candidate.managedKeysSha256)
     );
+  }
+  if (candidate.mode === "bundled-s3") {
+    if (
+      typeof candidate.bucket !== "string" || !candidate.bucket ||
+      typeof candidate.region !== "string" || !candidate.region ||
+      typeof candidate.directory !== "string" || !candidate.directory ||
+      !Number.isSafeInteger(candidate.fileCount) || Number(candidate.fileCount) < 0 ||
+      !Number.isSafeInteger(candidate.totalBytes) || Number(candidate.totalBytes) < 0 ||
+      !Array.isArray(candidate.objects) || candidate.objects.length !== candidate.fileCount
+    ) return false;
+    const keys = new Set<string>();
+    const files = new Set<string>();
+    for (const value of candidate.objects) {
+      if (!value || typeof value !== "object") return false;
+      const entry = value as Record<string, unknown>;
+      if (
+        typeof entry.key !== "string" || !entry.key ||
+        sanitizeStorageKey(entry.key) !== entry.key ||
+        typeof entry.file !== "string" || !isSafeRelativePath(entry.file) ||
+        !Number.isSafeInteger(entry.bytes) || Number(entry.bytes) < 0 ||
+        !isHexDigest(entry.sha256) ||
+        keys.has(entry.key) || files.has(entry.file)
+      ) return false;
+      keys.add(entry.key);
+      files.add(entry.file);
+    }
+    return true;
   }
   if (candidate.mode !== "bundled-local") return false;
   if (
@@ -206,6 +255,58 @@ export function createExternalS3Manifest(
   };
 }
 
+export async function createS3StorageSnapshot(
+  databasePath: string,
+  temporarySnapshotPath: string,
+  publishedDirectoryName: string,
+  bucket: string,
+  region: string,
+  readObject: (key: string, options: { maxBytes: number }) => Promise<Buffer>,
+): Promise<BundledS3StorageManifest> {
+  const keys = managedStorageKeys(databasePath);
+  if (keys.length > MAX_BACKUP_STORAGE_FILES) {
+    throw new Error(`S3 evidence inventory exceeds the ${MAX_BACKUP_STORAGE_FILES}-object backup limit.`);
+  }
+  const snapshotRoot = path.resolve(temporarySnapshotPath);
+  fs.mkdirSync(snapshotRoot, { recursive: false });
+  let totalBytes = 0;
+  const objects: BundledS3StorageManifest["objects"] = [];
+  for (const key of keys) {
+    const body = await readObject(key, { maxBytes: MAX_BACKUP_STORAGE_OBJECT_BYTES });
+    if (!Buffer.isBuffer(body)) throw new Error(`S3 evidence reader returned invalid bytes for: ${key}`);
+    totalBytes += body.length;
+    if (totalBytes > MAX_BACKUP_STORAGE_TOTAL_BYTES) {
+      throw new Error("S3 evidence snapshot exceeds the 100 GB backup-set limit.");
+    }
+    const file = `objects/${crypto.createHash("sha256").update(key).digest("hex")}`;
+    const destination = resolveInside(snapshotRoot, file);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.writeFileSync(destination, body, { flag: "wx", mode: 0o600 });
+    objects.push({
+      key,
+      file,
+      bytes: body.length,
+      sha256: crypto.createHash("sha256").update(body).digest("hex"),
+    });
+  }
+  const files = listStorageFiles(snapshotRoot);
+  const expectedFiles = objects
+    .map((entry) => ({ path: entry.file, bytes: entry.bytes, sha256: entry.sha256 }))
+    .sort((left, right) => compareText(left.path, right.path));
+  if (!sameFiles(files, expectedFiles)) {
+    throw new Error("S3 evidence snapshot does not match the backup database key inventory.");
+  }
+  return {
+    mode: "bundled-s3",
+    bucket,
+    region,
+    directory: publishedDirectoryName,
+    fileCount: objects.length,
+    totalBytes,
+    objects,
+  };
+}
+
 export function validateBackupStorage(
   databasePath: string,
   storagePath: string,
@@ -227,6 +328,28 @@ export function validateBackupStorage(
       return { valid: true };
     }
 
+    if (manifest.mode === "bundled-s3") {
+      if (manifest.directory !== expectedPublishedDirectoryName) {
+        return { valid: false, reason: "Bundled S3 evidence directory does not match its manifest." };
+      }
+      const objectKeys = manifest.objects.map((entry) => entry.key).sort(compareText);
+      if (JSON.stringify(objectKeys) !== JSON.stringify(keys)) {
+        return { valid: false, reason: "Bundled S3 key inventory does not match the backup database." };
+      }
+      const files = listStorageFiles(storagePath);
+      const expectedFiles = manifest.objects
+        .map((entry) => ({ path: entry.file, bytes: entry.bytes, sha256: entry.sha256 }))
+        .sort((left, right) => compareText(left.path, right.path));
+      if (
+        manifest.fileCount !== files.length ||
+        manifest.totalBytes !== files.reduce((total, entry) => total + entry.bytes, 0) ||
+        !sameFiles(expectedFiles, files)
+      ) {
+        return { valid: false, reason: "Bundled S3 evidence inventory does not match its manifest." };
+      }
+      return { valid: true };
+    }
+
     if (manifest.directory !== expectedPublishedDirectoryName) {
       return { valid: false, reason: "Local evidence directory does not match its manifest." };
     }
@@ -236,7 +359,10 @@ export function validateBackupStorage(
       manifest.totalBytes !== files.reduce((total, entry) => total + entry.bytes, 0) ||
       !sameFiles(manifest.files, files)
     ) {
-      return { valid: false, reason: "Local evidence inventory does not match its manifest." };
+      return {
+        valid: false,
+        reason: "Local evidence inventory does not match its manifest.",
+      };
     }
     const available = new Set(files.map((entry) => entry.path));
     const missing = keys.filter((key) => !available.has(key));
@@ -250,6 +376,10 @@ export function validateBackupStorage(
   } catch (error) {
     return { valid: false, reason: error instanceof Error ? error.message : String(error) };
   }
+}
+
+export function readStorageSnapshotFile(snapshotPath: string, relativePath: string): Buffer {
+  return fs.readFileSync(resolveInside(snapshotPath, relativePath));
 }
 
 function removePath(filePath: string): void {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -118,7 +118,15 @@ export async function storageGet(key: string): Promise<string> {
   return `file://${full}`;
 }
 
-export async function storageRead(key: string, options?: { maxBytes: number }): Promise<Buffer> {
+export interface StorageBackupObject {
+  body: Buffer;
+  contentType: string;
+}
+
+async function readStorageObject(
+  key: string,
+  options?: { maxBytes: number },
+): Promise<StorageBackupObject> {
   const safeKey = sanitizeStorageKey(key);
   if (!safeKey) throw new Error('Storage key must contain at least one valid path segment');
   const label = 'Storage object';
@@ -128,8 +136,10 @@ export async function storageRead(key: string, options?: { maxBytes: number }): 
     if (options && typeof response.ContentLength === 'number' && response.ContentLength > options.maxBytes) {
       throw new Error(`${label} exceeds the ${options.maxBytes} byte read limit`);
     }
-    if (options) return collectBoundedBytes(response.Body, { maxBytes: options.maxBytes, label });
-    return Buffer.from(await response.Body.transformToByteArray());
+    const body = options
+      ? await collectBoundedBytes(response.Body, { maxBytes: options.maxBytes, label })
+      : Buffer.from(await response.Body.transformToByteArray());
+    return { body, contentType: response.ContentType || 'application/octet-stream' };
   }
   const full = resolveLocalPath(safeKey);
   if (!fs.existsSync(full)) throw new Error(`Local storage object not found: ${safeKey}`);
@@ -139,7 +149,18 @@ export async function storageRead(key: string, options?: { maxBytes: number }): 
       throw new Error(`${label} exceeds the ${options.maxBytes} byte read limit`);
     }
   }
-  return fs.readFileSync(full);
+  return { body: fs.readFileSync(full), contentType: 'application/octet-stream' };
+}
+
+export async function storageRead(key: string, options?: { maxBytes: number }): Promise<Buffer> {
+  return (await readStorageObject(key, options)).body;
+}
+
+export async function storageReadForBackup(
+  key: string,
+  options: { maxBytes: number },
+): Promise<StorageBackupObject> {
+  return readStorageObject(key, options);
 }
 
 export async function storageOpenReadStream(

--- a/tests/backend/backupSet.test.ts
+++ b/tests/backend/backupSet.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { createHash } from 'crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   backupSetManifestPath,
@@ -23,6 +24,10 @@ function desktopSecrets(jwt = '1', cookie = '2') {
     jwtSecret: jwt.repeat(64),
     cookieSecret: cookie.repeat(64),
   };
+}
+
+function bundledS3File(key: string): string {
+  return path.join('objects', createHash('sha256').update(key).digest('hex'));
 }
 
 suite('recovery-ready backup sets', () => {
@@ -72,7 +77,7 @@ suite('recovery-ready backup sets', () => {
     expect(result.storagePath).toBe(backupSetStoragePath(destination));
     expect(validation.valid).toBe(true);
     expect(validation.storageCoverage).toBe('complete-local');
-    expect(validation.manifest?.version).toBe(2);
+    expect(validation.manifest?.version).toBe(3);
     expect(validation.manifest?.encryption.mode).toBe('bundled-desktop-secret');
     expect(validation.manifest?.storage).toMatchObject({
       mode: 'bundled-local',
@@ -156,10 +161,10 @@ suite('recovery-ready backup sets', () => {
       valid: false,
       reason: expect.stringContaining('incompatible'),
     });
-    expect(() => restoreBackupSet(destination, {
+    await expect(restoreBackupSet(destination, {
       externalJwtSecret: correctSecret,
       desktopSecretsPath: secretsPath,
-    })).toThrow('desktop profile with incompatible keys');
+    })).rejects.toThrow('desktop profile with incompatible keys');
   });
 
   it('rejects an active environment key that would override bundled desktop secrets', async () => {
@@ -167,35 +172,77 @@ suite('recovery-ready backup sets', () => {
     await createBackupSet(destination, { desktopSecretsPath: secretsPath });
     const secretsBefore = fs.readFileSync(secretsPath, 'utf8');
 
-    expect(() => restoreBackupSet(destination, {
+    await expect(restoreBackupSet(destination, {
       desktopSecretsPath: secretsPath,
       externalJwtSecret: 'active-environment-secret-that-does-not-match',
-    })).toThrow('active JWT_SECRET overrides its bundled key');
+    })).rejects.toThrow('active JWT_SECRET overrides its bundled key');
     expect(fs.readFileSync(secretsPath, 'utf8')).toBe(secretsBefore);
   });
 
-  it('records S3 key inventory and rejects a different restore target', async () => {
+  it('bundles and restores S3 evidence bytes and rejects a different restore target', async () => {
     const destination = path.join(app.tmpDir, 'external-s3.sqlite');
     const previousBucket = process.env.AWS_S3_BUCKET;
     const previousRegion = process.env.AWS_S3_REGION;
     const jwtSecret = desktopSecrets().jwtSecret;
+    const objects = new Map([[managedKey, Buffer.from(originalEvidence)]]);
     try {
       process.env.AWS_S3_BUCKET = 'laro-evidence-backup-a';
       process.env.AWS_S3_REGION = 'eu-west-1';
-      await createBackupSet(destination, { externalJwtSecret: jwtSecret });
+      await createBackupSet(destination, {
+        externalJwtSecret: jwtSecret,
+        externalStorageRead: async (key) => {
+          const value = objects.get(key);
+          if (!value) throw new Error(`missing ${key}`);
+          return Buffer.from(value);
+        },
+      });
       const validation = validateBackupSet(destination, { externalJwtSecret: jwtSecret });
       expect(validation.valid).toBe(true);
-      expect(validation.storageCoverage).toBe('external-s3');
+      expect(validation.storageCoverage).toBe('complete-s3');
       expect(validation.manifest?.storage).toMatchObject({
-        mode: 'external-s3',
+        mode: 'bundled-s3',
         bucket: 'laro-evidence-backup-a',
-        managedKeyCount: 1,
+        fileCount: 1,
       });
+      const bundledObject = path.join(backupSetStoragePath(destination), bundledS3File(managedKey));
+      expect(fs.readFileSync(bundledObject, 'utf8')).toBe(originalEvidence);
+      fs.appendFileSync(bundledObject, 'tamper');
+      expect(validateBackupSet(destination, { externalJwtSecret: jwtSecret })).toMatchObject({
+        valid: false,
+        reason: expect.stringContaining('Bundled S3 evidence inventory'),
+      });
+      fs.writeFileSync(bundledObject, originalEvidence);
+      expect(validateBackupSet(destination, { externalJwtSecret: jwtSecret }).valid).toBe(true);
+
       process.env.AWS_S3_BUCKET = 'laro-evidence-backup-b';
-      expect(() => restoreBackupSet(destination, {
+      await expect(restoreBackupSet(destination, {
         externalJwtSecret: jwtSecret,
         desktopSecretsPath: secretsPath,
-      })).toThrow('active S3 bucket or region differs');
+      })).rejects.toThrow('active S3 bucket or region differs');
+
+      process.env.AWS_S3_BUCKET = 'laro-evidence-backup-a';
+      objects.set(managedKey, Buffer.from('changed remote evidence'));
+      const restored = await restoreBackupSet(destination, {
+        externalJwtSecret: jwtSecret,
+        desktopSecretsPath: secretsPath,
+        externalStorageRead: async (key) => {
+          const value = objects.get(key);
+          if (!value) throw new Error(`missing ${key}`);
+          return Buffer.from(value);
+        },
+        externalStoragePut: async (key, body) => {
+          objects.set(key, Buffer.from(body));
+          return { sha256: (await import('../../server/storage')).hashBuffer(body) };
+        },
+        externalStorageDelete: async (key) => { objects.delete(key); },
+      });
+      app.db = await (await import('../../server/db')).getDb();
+      expect(objects.get(managedKey)?.toString('utf8')).toBe(originalEvidence);
+      expect(restored.backupOfPreviousStorage).toBeTruthy();
+      expect(fs.readFileSync(
+        path.join(restored.backupOfPreviousStorage!, bundledS3File(managedKey)),
+        'utf8',
+      )).toBe('changed remote evidence');
     } finally {
       if (previousBucket === undefined) delete process.env.AWS_S3_BUCKET;
       else process.env.AWS_S3_BUCKET = previousBucket;
@@ -217,8 +264,166 @@ suite('recovery-ready backup sets', () => {
       valid: true,
       storageCoverage: 'legacy-missing',
     });
-    expect(() => restoreBackupSet(destination, { desktopSecretsPath: secretsPath }))
-      .toThrow('local evidence coverage is not proven');
+    await expect(restoreBackupSet(destination, { desktopSecretsPath: secretsPath }))
+      .rejects.toThrow('evidence coverage is not proven');
+  });
+
+  it('does not publish an S3 backup set when referenced bytes are unavailable', async () => {
+    const destination = path.join(app.tmpDir, 'missing-s3-evidence.sqlite');
+    const previousBucket = process.env.AWS_S3_BUCKET;
+    try {
+      process.env.AWS_S3_BUCKET = 'laro-evidence-backup-a';
+      await expect(createBackupSet(destination, {
+        externalJwtSecret: desktopSecrets().jwtSecret,
+        externalStorageRead: async (key) => { throw new Error(`missing remote object ${key}`); },
+      })).rejects.toThrow('missing remote object');
+      expect(fs.existsSync(destination)).toBe(false);
+      expect(fs.existsSync(backupSetManifestPath(destination))).toBe(false);
+      expect(fs.existsSync(backupSetStoragePath(destination))).toBe(false);
+    } finally {
+      if (previousBucket === undefined) delete process.env.AWS_S3_BUCKET;
+      else process.env.AWS_S3_BUCKET = previousBucket;
+    }
+  });
+
+  it('stores Windows-hostile S3 keys under portable content-addressed filenames', async () => {
+    const destination = path.join(app.tmpDir, 'portable-s3-key.sqlite');
+    const hostileKey = 'evidence/backup-set/2026-08-22T12:00?.txt';
+    const previousBucket = process.env.AWS_S3_BUCKET;
+    try {
+      (app.db as any).$client.prepare(`
+        INSERT INTO evidence_files (id, userId, fileName, fileType, fileSize, storageKey)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(
+        'BACKUP_SET_HOSTILE_KEY',
+        'BACKUP_SET_MARKER',
+        'hostile-key.txt',
+        'text/plain',
+        '14',
+        hostileKey,
+      );
+      process.env.AWS_S3_BUCKET = 'laro-evidence-backup-a';
+      const objects = new Map([
+        [managedKey, Buffer.from(originalEvidence)],
+        [hostileKey, Buffer.from('portable bytes')],
+      ]);
+      await createBackupSet(destination, {
+        externalJwtSecret: desktopSecrets().jwtSecret,
+        externalStorageRead: async (key) => Buffer.from(objects.get(key)!),
+      });
+      const validation = validateBackupSet(destination, {
+        externalJwtSecret: desktopSecrets().jwtSecret,
+      });
+      expect(validation.valid).toBe(true);
+      const storage = validation.manifest?.storage;
+      expect(storage?.mode).toBe('bundled-s3');
+      if (storage?.mode !== 'bundled-s3') throw new Error('Expected bundled S3 storage');
+      const hostileObject = storage.objects.find((entry) => entry.key === hostileKey);
+      expect(hostileObject?.file).toMatch(/^objects\/[a-f0-9]{64}$/);
+      expect(fs.readFileSync(
+        path.join(backupSetStoragePath(destination), ...hostileObject!.file.split('/')),
+        'utf8',
+      )).toBe('portable bytes');
+    } finally {
+      (app.db as any).$client.prepare('DELETE FROM evidence_files WHERE id = ?')
+        .run('BACKUP_SET_HOSTILE_KEY');
+      if (previousBucket === undefined) delete process.env.AWS_S3_BUCKET;
+      else process.env.AWS_S3_BUCKET = previousBucket;
+    }
+  });
+
+  it('labels version-2 S3 inventories as incomplete and blocks restore by default', async () => {
+    const destination = path.join(app.tmpDir, 'version-two-s3.sqlite');
+    await createBackupSet(destination, { desktopSecretsPath: secretsPath });
+    const manifestPath = backupSetManifestPath(destination);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.version = 2;
+    manifest.storage = {
+      mode: 'external-s3',
+      bucket: 'legacy-inventory-only',
+      region: 'eu-west-1',
+      managedKeyCount: 1,
+      managedKeysSha256: createHash('sha256').update(JSON.stringify([managedKey])).digest('hex'),
+    };
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    fs.rmSync(backupSetStoragePath(destination), { recursive: true, force: true });
+
+    expect(validateBackupSet(destination)).toMatchObject({
+      valid: true,
+      storageCoverage: 'legacy-external-s3',
+    });
+    await expect(restoreBackupSet(destination, { desktopSecretsPath: secretsPath }))
+      .rejects.toThrow('evidence coverage is not proven');
+  });
+
+  it('rolls back a newly introduced S3 object when restore verification fails', async () => {
+    const destination = path.join(app.tmpDir, 's3-rollback.sqlite');
+    const previousBucket = process.env.AWS_S3_BUCKET;
+    const previousRegion = process.env.AWS_S3_REGION;
+    const jwtSecret = desktopSecrets().jwtSecret;
+    const objects = new Map([[managedKey, Buffer.from(originalEvidence)]]);
+    try {
+      process.env.AWS_S3_BUCKET = 'laro-evidence-backup-a';
+      process.env.AWS_S3_REGION = 'eu-west-1';
+      const read = async (key: string) => {
+        const value = objects.get(key);
+        if (!value) throw new Error(`missing ${key}`);
+        return Buffer.from(value);
+      };
+      await createBackupSet(destination, {
+        externalJwtSecret: jwtSecret,
+        externalStorageRead: read,
+      });
+
+      (app.db as any).$client.prepare('DELETE FROM evidence_files WHERE id = ?')
+        .run('BACKUP_SET_EVIDENCE');
+      objects.delete(managedKey);
+      for (const failure of ['hash-mismatch', 'acknowledgement-loss', 'remote-corruption'] as const) {
+        let writes = 0;
+        await expect(restoreBackupSet(destination, {
+          externalJwtSecret: jwtSecret,
+          desktopSecretsPath: secretsPath,
+          externalStorageRead: read,
+          externalStoragePut: async (key, body) => {
+            writes += 1;
+            objects.set(key, Buffer.from(body));
+            if (failure === 'acknowledgement-loss') {
+              throw new Error('simulated acknowledgement loss after remote write');
+            }
+            if (failure === 'remote-corruption') {
+              objects.set(key, Buffer.from('corrupted after upload'));
+              return { sha256: (await import('../../server/storage')).hashBuffer(body) };
+            }
+            return { sha256: '0'.repeat(64) };
+          },
+          externalStorageDelete: async (key) => { objects.delete(key); },
+        })).rejects.toThrow(
+          failure === 'hash-mismatch'
+            ? 'hash does not match'
+            : failure === 'acknowledgement-loss' ? 'acknowledgement loss' : 'read-back hash',
+        );
+        expect(writes).toBe(1);
+        expect(objects.has(managedKey)).toBe(false);
+      }
+    } finally {
+      if (previousBucket === undefined) delete process.env.AWS_S3_BUCKET;
+      else process.env.AWS_S3_BUCKET = previousBucket;
+      if (previousRegion === undefined) delete process.env.AWS_S3_REGION;
+      else process.env.AWS_S3_REGION = previousRegion;
+      app.db = await (await import('../../server/db')).getDb();
+      (app.db as any).$client.prepare(`
+        INSERT OR IGNORE INTO evidence_files
+          (id, userId, fileName, fileType, fileSize, storageKey)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(
+        'BACKUP_SET_EVIDENCE',
+        'BACKUP_SET_MARKER',
+        'source.txt',
+        'text/plain',
+        String(Buffer.byteLength(originalEvidence)),
+        managedKey,
+      );
+    }
   });
 
   it('rechecks the staged database against its manifest before replacing live data', async () => {
@@ -269,7 +474,7 @@ suite('recovery-ready backup sets', () => {
     fs.writeFileSync(secretsPath, JSON.stringify(desktopSecrets('3', '4'), null, 2), { mode: 0o600 });
     fs.writeFileSync(path.join(storagePath, ...managedKey.split('/')), 'changed evidence');
 
-    const result = restoreBackupSet(destination, { desktopSecretsPath: secretsPath });
+    const result = await restoreBackupSet(destination, { desktopSecretsPath: secretsPath });
     const reopened = await (await import('../../server/db')).getDb();
     const marker = (reopened as any).$client
       .prepare('SELECT id FROM users WHERE id = ?')

--- a/tests/backend/backupSet.test.ts
+++ b/tests/backend/backupSet.test.ts
@@ -185,6 +185,7 @@ suite('recovery-ready backup sets', () => {
     const previousRegion = process.env.AWS_S3_REGION;
     const jwtSecret = desktopSecrets().jwtSecret;
     const objects = new Map([[managedKey, Buffer.from(originalEvidence)]]);
+    const contentTypes = new Map([[managedKey, 'text/plain']]);
     try {
       process.env.AWS_S3_BUCKET = 'laro-evidence-backup-a';
       process.env.AWS_S3_REGION = 'eu-west-1';
@@ -193,7 +194,7 @@ suite('recovery-ready backup sets', () => {
         externalStorageRead: async (key) => {
           const value = objects.get(key);
           if (!value) throw new Error(`missing ${key}`);
-          return Buffer.from(value);
+          return { body: Buffer.from(value), contentType: contentTypes.get(key) || 'application/octet-stream' };
         },
       });
       const validation = validateBackupSet(destination, { externalJwtSecret: jwtSecret });
@@ -222,27 +223,38 @@ suite('recovery-ready backup sets', () => {
 
       process.env.AWS_S3_BUCKET = 'laro-evidence-backup-a';
       objects.set(managedKey, Buffer.from('changed remote evidence'));
+      contentTypes.set(managedKey, 'application/pdf');
       const restored = await restoreBackupSet(destination, {
         externalJwtSecret: jwtSecret,
         desktopSecretsPath: secretsPath,
         externalStorageRead: async (key) => {
           const value = objects.get(key);
           if (!value) throw new Error(`missing ${key}`);
-          return Buffer.from(value);
+          return { body: Buffer.from(value), contentType: contentTypes.get(key) || 'application/octet-stream' };
         },
-        externalStoragePut: async (key, body) => {
+        externalStoragePut: async (key, body, contentType) => {
           objects.set(key, Buffer.from(body));
+          contentTypes.set(key, contentType);
           return { sha256: (await import('../../server/storage')).hashBuffer(body) };
         },
         externalStorageDelete: async (key) => { objects.delete(key); },
       });
       app.db = await (await import('../../server/db')).getDb();
       expect(objects.get(managedKey)?.toString('utf8')).toBe(originalEvidence);
+      expect(contentTypes.get(managedKey)).toBe('text/plain');
       expect(restored.backupOfPreviousStorage).toBeTruthy();
       expect(fs.readFileSync(
         path.join(restored.backupOfPreviousStorage!, bundledS3File(managedKey)),
         'utf8',
       )).toBe('changed remote evidence');
+      const previousManifest = JSON.parse(fs.readFileSync(
+        `${restored.backupOfPreviousStorage}.manifest.json`,
+        'utf8',
+      ));
+      expect(previousManifest.objects).toContainEqual(expect.objectContaining({
+        key: managedKey,
+        contentType: 'application/pdf',
+      }));
     } finally {
       if (previousBucket === undefined) delete process.env.AWS_S3_BUCKET;
       else process.env.AWS_S3_BUCKET = previousBucket;
@@ -309,7 +321,10 @@ suite('recovery-ready backup sets', () => {
       ]);
       await createBackupSet(destination, {
         externalJwtSecret: desktopSecrets().jwtSecret,
-        externalStorageRead: async (key) => Buffer.from(objects.get(key)!),
+        externalStorageRead: async (key) => ({
+          body: Buffer.from(objects.get(key)!),
+          contentType: 'text/plain',
+        }),
       });
       const validation = validateBackupSet(destination, {
         externalJwtSecret: desktopSecrets().jwtSecret,
@@ -368,7 +383,7 @@ suite('recovery-ready backup sets', () => {
       const read = async (key: string) => {
         const value = objects.get(key);
         if (!value) throw new Error(`missing ${key}`);
-        return Buffer.from(value);
+        return { body: Buffer.from(value), contentType: 'text/plain' };
       };
       await createBackupSet(destination, {
         externalJwtSecret: jwtSecret,

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -634,9 +634,12 @@ describe('production readiness regressions', () => {
     expect(backupSet).toContain('Staged desktop secrets do not match');
     expect(backupCore).toContain('staged database does not match the backup-set manifest');
     expect(backupStorage).toContain('bundled-local');
-    expect(backupStorage).toContain('external-s3');
+    expect(backupStorage).toContain('bundled-s3');
+    expect(backupStorage).toContain('createS3StorageSnapshot');
     expect(backupStorage).toContain('assertLocalStorageUnchanged');
     expect(backupStorage).toContain('managed local evidence object(s)');
+    expect(backupSet).toContain('s3Install.rollback()');
+    expect(backupSet).toContain('legacy-external-s3');
     expect(backupCli).toContain('Refusing a database-only restore');
     expect(backupCli).toContain('parsed.allowLegacy');
     expect(backupCli).toContain('parsed.allowMissingStorage');

--- a/tests/security/productionReadiness.test.ts
+++ b/tests/security/productionReadiness.test.ts
@@ -636,9 +636,11 @@ describe('production readiness regressions', () => {
     expect(backupStorage).toContain('bundled-local');
     expect(backupStorage).toContain('bundled-s3');
     expect(backupStorage).toContain('createS3StorageSnapshot');
+    expect(backupStorage).toContain('contentType');
     expect(backupStorage).toContain('assertLocalStorageUnchanged');
     expect(backupStorage).toContain('managed local evidence object(s)');
     expect(backupSet).toContain('s3Install.rollback()');
+    expect(backupSet).toContain('readBack.contentType !== entry.contentType');
     expect(backupSet).toContain('legacy-external-s3');
     expect(backupCli).toContain('Refusing a database-only restore');
     expect(backupCli).toContain('parsed.allowLegacy');


### PR DESCRIPTION
## Summary
- introduce version-3 recovery sets that bundle the raw bytes of every database-referenced S3 object with bounded size/count/total limits and SHA-256 manifests
- restore bundled S3 evidence only to the recorded bucket and region, preserve the previous remote state, verify every write by read-back, and roll back partial or ambiguous failures
- keep version-1 and version-2 inventory-only sets readable but classify them as incomplete and block normal restore
- use content-addressed portable snapshot filenames so legal S3 keys remain recoverable on Windows

## Verification
- npm.cmd run gate
- 97 test files, 585 tests passed
- renderer/server/main type checks, lint, bundle budget, dependency audits, traceability, account safety, and both recovery drills passed

## Security finding closed
The previous S3 manifest contained only key names, so deleting or replacing live objects could leave validation green while evidence bytes were unrecoverable. Version 3 owns and verifies the raw evidence bytes inside the recovery set instead of relying on mutable live S3 objects.