### PR TITLE
Make legal workflow audits atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,10 @@ summary fields, but excludes contacts, source bytes/quotes, and provider secrets
 - Case and outreach status changes use owner-bound compare-and-set writes; a
   stale request fails instead of overwriting a newer decision. Recording an
   interested response updates the outreach and case together or rolls both back.
+- Required audit evidence is committed in the same database transaction as the
+  case lifecycle, outreach initiation, draft approval/rejection, dispatch
+  claims, response classification, and Gmail reply linking. A failed audit
+  write rolls back the legal state change; batch approvals are all-or-nothing.
 - Missing/failed providers never create a false `Sent` state.
 
 ### Privacy and Erasure
@@ -651,7 +655,7 @@ deterministic tests, explicit live acceptance, and documentation.
 budgets, dependency audits, release-record validity, traceability, safety scans,
 Electron and Flask recovery drills, and Vitest.
 
-On 2026-08-22, the fresh gate passed **98 test files and 590 tests**, with 0
+On 2026-08-22, the fresh gate passed **98 test files and 600 tests**, with 0
 dependency vulnerabilities, 117/117 traceability rows cited, 0 suspect runtime
 placeholders, and 0 high-severity account-safety findings. This is a dated local
 verification snapshot; use the latest

--- a/docs/NO_EXCUSES_SEARCH.md
+++ b/docs/NO_EXCUSES_SEARCH.md
@@ -25,7 +25,7 @@ Descriptive words (mock/stub/placeholder/fake) needing human judgement. Triage o
 | `server/managedStorage.ts` | 56 | `rows = sqlite.prepare(`SELECT ${select} FROM "${table}" WHERE caseId IN (${placeholders})`).all(...scope.caseIds);` |
 | `server/notifications.ts` | 10 | `* stub; this one persists user-facing notifications.` |
 | `server/outreachSend.ts` | 16 | `* The email sender is injectable so tests exercise the full path with a fake` |
-| `server/outreachSend.ts` | 286 | `* `sender` is injectable (tests pass a fake); production uses systemEmail.` |
+| `server/outreachSend.ts` | 300 | `* `sender` is injectable (tests pass a fake); production uses systemEmail.` |
 | `server/routers/cases.ts` | 151 | `// empty GDPR stub.` |
 | `server/routers/enhancedConnections.ts` | 102 | `// Honest unavailability — no fake auth URL.` |
 | `server/routers/extendedRouters.ts` | 6 | `* run. No fake success (Phase 014).` |

--- a/docs/NO_EXCUSES_SEARCH.md
+++ b/docs/NO_EXCUSES_SEARCH.md
@@ -25,11 +25,11 @@ Descriptive words (mock/stub/placeholder/fake) needing human judgement. Triage o
 | `server/managedStorage.ts` | 56 | `rows = sqlite.prepare(`SELECT ${select} FROM "${table}" WHERE caseId IN (${placeholders})`).all(...scope.caseIds);` |
 | `server/notifications.ts` | 10 | `* stub; this one persists user-facing notifications.` |
 | `server/outreachSend.ts` | 16 | `* The email sender is injectable so tests exercise the full path with a fake` |
-| `server/outreachSend.ts` | 279 | `* `sender` is injectable (tests pass a fake); production uses systemEmail.` |
-| `server/routers/cases.ts` | 150 | `// empty GDPR stub.` |
+| `server/outreachSend.ts` | 286 | `* `sender` is injectable (tests pass a fake); production uses systemEmail.` |
+| `server/routers/cases.ts` | 151 | `// empty GDPR stub.` |
 | `server/routers/enhancedConnections.ts` | 102 | `// Honest unavailability — no fake auth URL.` |
 | `server/routers/extendedRouters.ts` | 6 | `* run. No fake success (Phase 014).` |
-| `server/routers/extendedRouters.ts` | 210 | `// provider is configured there is nothing to sync (honest, not a fake OK).` |
+| `server/routers/extendedRouters.ts` | 211 | `// provider is configured there is nothing to sync (honest, not a fake OK).` |
 | `server/routers/index.ts` | 396 | `// stub): computes genuine clarifications the user must resolve BEFORE outreach` |
 | `server/routers/matching.ts` | 22 | `*  - If no lawyers are seeded/entered, the result is genuinely empty (no fakes).` |
 | `server/storage.ts` | 10 | `*    fake `/local/<key>` URL. That silent data loss is fixed.` |

--- a/docs/TECHNICAL_AUDIT.md
+++ b/docs/TECHNICAL_AUDIT.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-22
 Branch: `main` (updates proposed through pull requests)
-Baseline commit: `48ccc59cd9ea3d594bb4b0ecad0da3a5b41ae179`
+Baseline commit: `ea37e9440dbb9e4b9c1feac6026495f5366d34c9`
 Specification: `000-LARO__Giant_Codex_Goal_Prompt.pdf`, 124 pages, phases 000-115
 
 ## Scope and method
@@ -63,6 +63,9 @@ recorded in `docs/ACCEPTANCE_TESTS.md` and `docs/MANUAL_VERIFICATION.md`.
   separate state transitions; delivery is disabled by default and fail-closed.
 - Case and outreach transitions claim their exact prior state. Response and case
   outcome changes are transactional, so stale or invalid requests roll back.
+- Required audit evidence is written in the same transaction as consequential
+  case and outreach changes. Audit failure rolls back the state change, and
+  multi-draft approval either commits every draft and audit row or commits none.
 - Evidence analysis distinguishes source observations from inference and keeps
   document/source identifiers available to the user.
 - Backup sets bind the database, encryption-key compatibility, and managed
@@ -89,6 +92,7 @@ recorded in `docs/ACCEPTANCE_TESTS.md` and `docs/MANUAL_VERIFICATION.md`.
 | S3 recovery sets recorded inventory without preserving evidence bytes | Medium | Version-3 sets bundle bounded, hashed object bytes and content types; restore verifies remote writes and rolls back on failure |
 | Case and response transitions used stale check-then-update writes | High | Owner-bound compare-and-set transitions reject stale state; response plus case outcome updates commit or roll back together; no-match outreach leaves the case unchanged |
 | An unreachable duplicate outreach engine retained unsafe state writers | Medium | Removed the unreferenced `server/workflow.ts`; the registered tRPC workflow is the only runtime outreach authority |
+| Consequential legal-state writes could survive a failed audit insert | High | Case creation, classification, editing, transition, and deletion plus outreach initiation, single and batch draft decisions, dispatch claims, responses, and Gmail reply linking now commit with required audit rows or roll back together; injected SQLite failures verify each boundary |
 
 ## Verdict
 

--- a/server/audit.ts
+++ b/server/audit.ts
@@ -3,7 +3,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { auditLogs, InsertAuditLog } from "./schema";
 import { getDb } from "./db";
 
-export async function createAuditLog(log: {
+export interface AuditLogInput {
   userId?: string;
   action: string;
   entityType?: string;
@@ -11,7 +11,24 @@ export async function createAuditLog(log: {
   details?: Record<string, any>;
   ipAddress?: string;
   userAgent?: string;
-}): Promise<void> {
+}
+
+export function writeAuditLogOrThrow(db: any, log: AuditLogInput): string {
+  const auditLog: InsertAuditLog = {
+    id: nanoid(),
+    userId: log.userId,
+    action: log.action,
+    entityType: log.entityType,
+    entityId: log.entityId,
+    details: log.details ? JSON.stringify(log.details) : null,
+    ipAddress: log.ipAddress,
+    userAgent: log.userAgent,
+  };
+  db.insert(auditLogs).values(auditLog).run();
+  return auditLog.id;
+}
+
+export async function createAuditLog(log: AuditLogInput): Promise<void> {
   const db = await getDb();
   if (!db) {
     console.warn("[Audit] Cannot create audit log: database not available");
@@ -19,18 +36,7 @@ export async function createAuditLog(log: {
   }
 
   try {
-    const auditLog: InsertAuditLog = {
-      id: nanoid(),
-      userId: log.userId,
-      action: log.action,
-      entityType: log.entityType,
-      entityId: log.entityId,
-      details: log.details ? JSON.stringify(log.details) : null,
-      ipAddress: log.ipAddress,
-      userAgent: log.userAgent,
-    };
-
-    await db.insert(auditLogs).values(auditLog);
+    writeAuditLogOrThrow(db, log);
   } catch (error) {
     console.error("[Audit] Failed to create audit log:", error);
   }

--- a/server/caseTransitions.ts
+++ b/server/caseTransitions.ts
@@ -4,6 +4,7 @@ import { assertCaseOwnership } from "./_core/authz";
 import { getDb } from "./db";
 import { cases } from "./schema";
 import { assertCaseTransition } from "./stateMachines";
+import { writeAuditLogOrThrow, type AuditLogInput } from "./audit";
 
 type CaseStatus = string | null;
 
@@ -18,6 +19,7 @@ interface CompareAndSetCaseStatusOptions {
     legalAreas?: string | null;
   };
   updatedAt?: Date;
+  audit?: AuditLogInput;
 }
 
 interface TransitionOwnedCaseStatusOptions {
@@ -26,6 +28,7 @@ interface TransitionOwnedCaseStatusOptions {
   nextStatus: string;
   changes?: CompareAndSetCaseStatusOptions["changes"];
   updatedAt?: Date;
+  audit?: AuditLogInput;
 }
 
 function transitionConflict(): TRPCError {
@@ -60,6 +63,9 @@ export function compareAndSetCaseStatusInTransaction(
   if (Number(result?.changes ?? 0) !== 1) {
     throw transitionConflict();
   }
+  if (options.audit) {
+    writeAuditLogOrThrow(db, options.audit);
+  }
   return { previousStatus: options.expectedStatus, status: options.nextStatus };
 }
 
@@ -67,7 +73,7 @@ export async function compareAndSetCaseStatus(
   db: any,
   options: CompareAndSetCaseStatusOptions,
 ): Promise<{ previousStatus: CaseStatus; status: string }> {
-  return compareAndSetCaseStatusInTransaction(db, options);
+  return db.transaction((tx: any) => compareAndSetCaseStatusInTransaction(tx, options));
 }
 
 export async function transitionOwnedCaseStatus(
@@ -93,5 +99,6 @@ export async function transitionOwnedCaseStatus(
     nextStatus: options.nextStatus,
     changes: options.changes,
     updatedAt: options.updatedAt,
+    audit: options.audit,
   });
 }

--- a/server/inboundOutreach.ts
+++ b/server/inboundOutreach.ts
@@ -1,5 +1,5 @@
-import { and, eq, inArray } from "drizzle-orm";
-import { AUDIT_ACTIONS, createAuditLog } from "./audit";
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import { AUDIT_ACTIONS, writeAuditLogOrThrow } from "./audit";
 import { getDb } from "./db";
 import { createNotification } from "./notifications";
 import { cases, lawyers, outreachStatus } from "./schema";
@@ -103,33 +103,42 @@ export async function linkInboundOutreachReply(options: {
   const responseTimeHours = firstContact
     ? Math.max(0, (options.message.receivedAt.getTime() - firstContact.getTime()) / 3_600_000).toFixed(2)
     : null;
-  await db.update(outreachStatus).set({
-    responseReceived: "Yes",
-    response: outreach.response || options.message.body.trim().slice(0, 5_000) || null,
-    responseTimeHours,
-    lastContact: options.message.receivedAt,
-    metadata: JSON.stringify({
-      ...metadata,
-      inboundGmailMessageIds: [...inboundMessageIds, options.message.gmailMessageId],
-      inboundGmailThreadId: options.message.gmailThreadId ?? metadata.inboundGmailThreadId ?? null,
-      latestInboundMessageId: options.message.messageId ?? null,
-      latestInboundAt: options.message.receivedAt.toISOString(),
-      responseNeedsClassification: !["Interested", "Declined"].includes(String(outreach.status)),
-    }),
-    updatedAt: new Date(),
-  }).where(eq(outreachStatus.id, outreach.id));
-
-  await createAuditLog({
-    userId: options.userId,
-    action: AUDIT_ACTIONS.EMAIL_RESPONSE_RECEIVED,
-    entityType: "outreach",
-    entityId: outreach.id,
-    details: {
-      caseId: options.caseId,
-      gmailMessageId: options.message.gmailMessageId,
-      gmailThreadId: options.message.gmailThreadId ?? null,
-      classification: ["Interested", "Declined"].includes(String(outreach.status)) ? outreach.status : "needs_review",
-    },
+  db.transaction((tx: any) => {
+    const mutation = tx.update(outreachStatus).set({
+      responseReceived: "Yes",
+      response: outreach.response || options.message.body.trim().slice(0, 5_000) || null,
+      responseTimeHours,
+      lastContact: options.message.receivedAt,
+      metadata: JSON.stringify({
+        ...metadata,
+        inboundGmailMessageIds: [...inboundMessageIds, options.message.gmailMessageId],
+        inboundGmailThreadId: options.message.gmailThreadId ?? metadata.inboundGmailThreadId ?? null,
+        latestInboundMessageId: options.message.messageId ?? null,
+        latestInboundAt: options.message.receivedAt.toISOString(),
+        responseNeedsClassification: !["Interested", "Declined"].includes(String(outreach.status)),
+      }),
+      updatedAt: new Date(),
+    }).where(and(
+      eq(outreachStatus.id, outreach.id),
+      outreach.metadata == null
+        ? isNull(outreachStatus.metadata)
+        : eq(outreachStatus.metadata, outreach.metadata),
+    )).run();
+    if (Number(mutation.changes || 0) !== 1) {
+      throw new Error("The outreach reply target changed before it could be linked");
+    }
+    writeAuditLogOrThrow(tx, {
+      userId: options.userId,
+      action: AUDIT_ACTIONS.EMAIL_RESPONSE_RECEIVED,
+      entityType: "outreach",
+      entityId: outreach.id,
+      details: {
+        caseId: options.caseId,
+        gmailMessageId: options.message.gmailMessageId,
+        gmailThreadId: options.message.gmailThreadId ?? null,
+        classification: ["Interested", "Declined"].includes(String(outreach.status)) ? outreach.status : "needs_review",
+      },
+    });
   });
   await createNotification({
     userId: options.userId,

--- a/server/outreachSend.ts
+++ b/server/outreachSend.ts
@@ -30,7 +30,7 @@ import { TRPCError } from "@trpc/server";
 import { getFlag } from "./featureFlags";
 import { assertNotEmergencyStopped } from "./systemState";
 import { assertOutreachTransition } from "./stateMachines";
-import { createAuditLog, AUDIT_ACTIONS } from "./audit";
+import { createAuditLog, AUDIT_ACTIONS, writeAuditLogOrThrow } from "./audit";
 import { assertCaseOwnership } from "./_core/authz";
 import { createNotification } from "./notifications";
 import { readApprovedOutreachMessage, readOutreachMetadata } from "./outreachApproval";
@@ -81,7 +81,7 @@ function readDispatchGuard(db: any, guardKey: string): string | null {
 
 class DispatchClaimConflict extends Error {}
 
-function claimDispatch(db: any, guardKey: string, dispatchId: string, outreachId: string): boolean {
+function claimDispatch(db: any, guardKey: string, dispatchId: string, outreachId: string, userId: string): boolean {
   try {
     db.transaction((tx: any) => {
       const now = new Date();
@@ -96,6 +96,13 @@ function claimDispatch(db: any, guardKey: string, dispatchId: string, outreachId
         .where(and(eq(outreachStatus.id, outreachId), eq(outreachStatus.status, "Approved")))
         .run();
       if (Number(status.changes || 0) !== 1) throw new DispatchClaimConflict();
+      writeAuditLogOrThrow(tx, {
+        userId,
+        action: AUDIT_ACTIONS.OUTREACH_STATUS_CHANGED,
+        entityType: "outreach",
+        entityId: outreachId,
+        details: { from: "Approved", to: "Dispatching", dispatchId },
+      });
     });
     return true;
   } catch (error) {
@@ -347,7 +354,7 @@ export async function sendApprovedOutreach(
   // Transmit. If no provider is configured, delivered=false → fail honestly.
   const dispatchId = nanoid();
   const dispatchState = `dispatching:${dispatchId}`;
-  if (!claimDispatch(db, guardKey, dispatchId, outreachId)) {
+  if (!claimDispatch(db, guardKey, dispatchId, outreachId, userId)) {
     const { TRPCError } = await import("@trpc/server");
     throw new TRPCError({
       code: "CONFLICT",
@@ -494,14 +501,13 @@ export async function recordOutreachResponse(
         updatedAt: respondedAt,
       });
     }
-  });
-
-  await createAuditLog({
-    userId,
-    action: AUDIT_ACTIONS.EMAIL_RESPONSE_RECEIVED,
-    entityType: "outreach",
-    entityId: outreachId,
-    details: { caseId: row.caseId, lawyerId: row.lawyerId, from: row.status, to: response, notes: notes?.trim() || null },
+    writeAuditLogOrThrow(tx, {
+      userId,
+      action: AUDIT_ACTIONS.EMAIL_RESPONSE_RECEIVED,
+      entityType: "outreach",
+      entityId: outreachId,
+      details: { caseId: row.caseId, lawyerId: row.lawyerId, from: row.status, to: response, notes: notes?.trim() || null },
+    });
   });
   await createNotification({
     userId,

--- a/server/outreachSend.ts
+++ b/server/outreachSend.ts
@@ -111,18 +111,32 @@ function claimDispatch(db: any, guardKey: string, dispatchId: string, outreachId
   }
 }
 
-function releaseUndeliveredClaim(db: any, guardKey: string, dispatchState: string, outreachId: string): void {
+function releaseUndeliveredClaim(
+  db: any,
+  guardKey: string,
+  dispatchState: string,
+  outreachId: string,
+  userId: string,
+): void {
   db.transaction((tx: any) => {
+    const now = new Date();
     const guard = tx.delete(systemConfig)
       .where(and(eq(systemConfig.configKey, guardKey), eq(systemConfig.configValue, dispatchState)))
       .run();
     const status = tx.update(outreachStatus)
-      .set({ status: "Approved", updatedAt: new Date() })
+      .set({ status: "Approved", updatedAt: now })
       .where(and(eq(outreachStatus.id, outreachId), eq(outreachStatus.status, "Dispatching")))
       .run();
     if (Number(guard.changes || 0) !== 1 || Number(status.changes || 0) !== 1) {
       throw new Error("Outreach dispatch claim changed before it could be released");
     }
+    writeAuditLogOrThrow(tx, {
+      userId,
+      action: AUDIT_ACTIONS.OUTREACH_STATUS_CHANGED,
+      entityType: "outreach",
+      entityId: outreachId,
+      details: { from: "Dispatching", to: "Approved", delivered: false },
+    });
   });
 }
 
@@ -370,7 +384,7 @@ export async function sendApprovedOutreach(
     throw error;
   }
   if (!result.delivered) {
-    releaseUndeliveredClaim(db, guardKey, dispatchState, outreachId);
+    releaseUndeliveredClaim(db, guardKey, dispatchState, outreachId, userId);
     const { TRPCError } = await import("@trpc/server");
     throw new TRPCError({ code: "PRECONDITION_FAILED", message: "No email provider is configured; nothing was sent. Configure SendGrid/SMTP." });
   }

--- a/server/routers/cases.ts
+++ b/server/routers/cases.ts
@@ -4,7 +4,7 @@ import { router, protectedProcedure } from "../_core/trpc";
 import { getDb } from "../db";
 import { assertCaseOwnership } from "../_core/authz";
 import { enforceRateLimit, RATE_LIMITS } from "../rateLimit";
-import { createAuditLog, AUDIT_ACTIONS } from "../audit";
+import { AUDIT_ACTIONS, writeAuditLogOrThrow } from "../audit";
 import { cases as casesTable, outreachStatus, lawyers, evidence, systemConfig } from '../schema';
 import { eq, desc, asc, and, sql } from "drizzle-orm";
 import { sanitizeLegalAreas } from "../legalAreasValidator";
@@ -111,28 +111,29 @@ export const casesRouter = router({
       // instead of the case being unclassified.
       const classification = classifyLegalAreas(input.caseSummary, input.caseType);
 
-      await db.insert(casesTable).values({
-        id: caseId,
-        userId,
-        clientName: input.clientName,
-        clientEmail: input.clientEmail,
-        clientPhone: input.clientPhone,
-        clientAddress: input.clientAddress,
-        caseType: input.caseType,
-        caseSummary: input.caseSummary,
-        urgency: input.urgency,
-        status: "Matching",
-        legalAreas: sanitizeLegalAreas(classification.areas),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      } as any);
-
-      await createAuditLog({ // Phase 019
-        userId,
-        action: AUDIT_ACTIONS.CASE_CREATED,
-        entityType: "case",
-        entityId: caseId,
-        details: { caseType: input.caseType, urgency: input.urgency, legalAreas: classification.areas },
+      db.transaction((tx: any) => {
+        tx.insert(casesTable).values({
+          id: caseId,
+          userId,
+          clientName: input.clientName,
+          clientEmail: input.clientEmail,
+          clientPhone: input.clientPhone,
+          clientAddress: input.clientAddress,
+          caseType: input.caseType,
+          caseSummary: input.caseSummary,
+          urgency: input.urgency,
+          status: "Matching",
+          legalAreas: sanitizeLegalAreas(classification.areas),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as any).run();
+        writeAuditLogOrThrow(tx, {
+          userId,
+          action: AUDIT_ACTIONS.CASE_CREATED,
+          entityType: "case",
+          entityId: caseId,
+          details: { caseType: input.caseType, urgency: input.urgency, legalAreas: classification.areas },
+        });
       });
 
       await createNotification({ // Phase 027
@@ -251,20 +252,22 @@ export const casesRouter = router({
       if (!c) throw new Error("Case not found");
 
       const classification = classifyLegalAreas(c.caseSummary || "", c.caseType || undefined);
-      const updateResult = await db
-        .update(casesTable)
-        .set({ legalAreas: sanitizeLegalAreas(classification.areas), updatedAt: new Date() })
-        .where(eq(casesTable.id, input.caseId));
-      if (!Number((updateResult as any)?.changes ?? 0)) {
-        throw new TRPCError({ code: "CONFLICT", message: "Case changed before classification could be saved" });
-      }
-
-      await createAuditLog({
-        userId: ctx.user.id,
-        action: AUDIT_ACTIONS.CASE_UPDATED,
-        entityType: "case",
-        entityId: input.caseId,
-        details: { classified: classification.areas, confidence: classification.confidence },
+      db.transaction((tx: any) => {
+        const updateResult = tx
+          .update(casesTable)
+          .set({ legalAreas: sanitizeLegalAreas(classification.areas), updatedAt: new Date() })
+          .where(eq(casesTable.id, input.caseId))
+          .run();
+        if (!Number(updateResult?.changes ?? 0)) {
+          throw new TRPCError({ code: "CONFLICT", message: "Case changed before classification could be saved" });
+        }
+        writeAuditLogOrThrow(tx, {
+          userId: ctx.user.id,
+          action: AUDIT_ACTIONS.CASE_UPDATED,
+          entityType: "case",
+          entityId: input.caseId,
+          details: { classified: classification.areas, confidence: classification.confidence },
+        });
       });
       emitRealtimeDataChange(ctx.user.id, { scope: "case", caseId: input.caseId });
 
@@ -299,23 +302,32 @@ export const casesRouter = router({
           nextStatus: input.status,
           changes: updateData,
           updatedAt: updateData.updatedAt,
+          audit: {
+            userId: ctx.user.id,
+            action: AUDIT_ACTIONS.CASE_STATUS_CHANGED,
+            entityType: "case",
+            entityId: input.id,
+            details: { to: input.status, fields: Object.keys(updateData) },
+          },
         });
       } else {
-        const updateResult = await db.update(casesTable)
-          .set(updateData)
-          .where(eq(casesTable.id, input.id));
-        if (!Number((updateResult as any)?.changes ?? 0)) {
-          throw new TRPCError({ code: "CONFLICT", message: "Case changed before the update could be saved" });
-        }
+        db.transaction((tx: any) => {
+          const updateResult = tx.update(casesTable)
+            .set(updateData)
+            .where(eq(casesTable.id, input.id))
+            .run();
+          if (!Number(updateResult?.changes ?? 0)) {
+            throw new TRPCError({ code: "CONFLICT", message: "Case changed before the update could be saved" });
+          }
+          writeAuditLogOrThrow(tx, {
+            userId: ctx.user.id,
+            action: AUDIT_ACTIONS.CASE_UPDATED,
+            entityType: "case",
+            entityId: input.id,
+            details: { fields: Object.keys(updateData) },
+          });
+        });
       }
-
-      await createAuditLog({ // Phase 019
-        userId: ctx.user.id,
-        action: input.status ? AUDIT_ACTIONS.CASE_STATUS_CHANGED : AUDIT_ACTIONS.CASE_UPDATED,
-        entityType: "case",
-        entityId: input.id,
-        details: { status: input.status, fields: Object.keys(updateData) },
-      });
       emitRealtimeDataChange(ctx.user.id, { scope: "case", caseId: input.id });
 
       return { success: true };
@@ -379,19 +391,18 @@ export const casesRouter = router({
         sqliteDb
           .prepare(`DELETE FROM cases WHERE id = ? AND userId = ?`)
           .run(caseId, userId);
+        writeAuditLogOrThrow(db, {
+          userId,
+          action: AUDIT_ACTIONS.CASE_DELETED,
+          entityType: "case",
+          entityId: caseId,
+          details: { cascadedTables: tablesWithCaseId },
+        });
       });
 
       tx(input.id, ctx.user.id);
 
       const cleanup = await processQueuedStorageDeletions({ storageKeys });
-
-      await createAuditLog({ // Phase 019
-        userId: ctx.user.id,
-        action: AUDIT_ACTIONS.CASE_DELETED,
-        entityType: "case",
-        entityId: input.id,
-        details: { cascadedTables: tablesWithCaseId },
-      });
 
       return {
         success: cleanup.requestedPending === 0,

--- a/server/routers/extendedRouters.ts
+++ b/server/routers/extendedRouters.ts
@@ -27,6 +27,7 @@ import {
 } from "../schema";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { assertCaseOwnership } from "../_core/authz";
+import { AUDIT_ACTIONS } from "../audit";
 import { nanoid } from "nanoid";
 
 const count = sql<number>`count(*)`;
@@ -285,6 +286,13 @@ export const caseManagementRouter = router({
       caseId: input.caseId,
       actorUserId: ctx.user.id,
       nextStatus: input.status,
+      audit: {
+        userId: ctx.user.id,
+        action: AUDIT_ACTIONS.CASE_STATUS_CHANGED,
+        entityType: "case",
+        entityId: input.caseId,
+        details: { to: input.status, source: "caseManagement.updateStatus" },
+      },
     });
     return { ok: true as const, status: input.status };
   }),

--- a/server/routers/workflow.ts
+++ b/server/routers/workflow.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { protectedProcedure, router } from "../_core/trpc";
 import { getDb } from "../db";
 import { assertCaseOwnership } from "../_core/authz";
 import { enforceRateLimit, RATE_LIMITS } from "../rateLimit";
-import { createAuditLog, AUDIT_ACTIONS } from "../audit";
+import { createAuditLog, AUDIT_ACTIONS, writeAuditLogOrThrow } from "../audit";
 import { createNotification } from "../notifications";
 import { getFlag } from "../featureFlags";
 import { assertNotEmergencyStopped } from "../systemState";
@@ -145,16 +146,15 @@ export const workflowRouter = router({
           ownerId: snapshot.ownerId,
           expectedStatus: snapshot.status,
           nextStatus: "Outreach",
+          audit: {
+            userId: ctx.user.id,
+            action: AUDIT_ACTIONS.OUTREACH_INITIATED,
+            entityType: "case",
+            entityId: input.caseId,
+            details: { from: snapshot.status, to: "Outreach", draftsPrepared: plan.matches.length, approvalMode: plan.approvalMode },
+          },
         });
         created = insertOutreachDraftRows(tx, input.caseId, plan.matches);
-      });
-
-      await createAuditLog({
-        userId: ctx.user.id,
-        action: AUDIT_ACTIONS.OUTREACH_INITIATED,
-        entityType: "case",
-        entityId: input.caseId,
-        details: { from: snapshot.status, to: "Outreach", draftsPrepared: plan.matches.length, approvalMode: plan.approvalMode },
       });
 
       return {
@@ -254,21 +254,15 @@ export const workflowRouter = router({
       await assertNotEmergencyStopped();
       const db = await getDb();
       if (!db) throw new Error("Database not available");
-      const ids = input.approvals.map((item) => item.outreachId);
-      const rows = await db.select({ id: outreachStatus.id, caseId: outreachStatus.caseId, status: outreachStatus.status })
-        .from(outreachStatus)
-        .where(inArray(outreachStatus.id, ids));
-      if (rows.length !== ids.length) throw new Error("One or more outreach drafts were not found");
-      for (const row of rows) {
-        if (!row.caseId) throw new Error("Outreach draft is not linked to a case");
-        await assertCaseOwnership(row.caseId, ctx.user.id);
-        assertOutreachTransition(row.status ?? null, OUTREACH_APPROVED);
-      }
-      const results = [];
+      const prepared: PreparedDraftStatus[] = [];
       for (const approval of input.approvals) {
-        results.push(await setDraftStatus(ctx.user.id, approval.outreachId, OUTREACH_APPROVED, approval.approvalHash));
+        prepared.push(await prepareDraftStatus(ctx.user.id, approval.outreachId, OUTREACH_APPROVED, approval.approvalHash));
       }
-      return { success: true as const, approved: results.length, sent: false as const };
+      db.transaction((tx: any) => {
+        for (const draft of prepared) applyDraftStatusInTransaction(tx, ctx.user.id, draft);
+      });
+      for (const draft of prepared) await notifyDraftStatus(ctx.user.id, draft.newStatus);
+      return { success: true as const, approved: prepared.length, sent: false as const };
     }),
 
   /** Phase 026 — reject a draft. */
@@ -367,7 +361,20 @@ export const workflowRouter = router({
     }),
 });
 
-async function setDraftStatus(userId: string, outreachId: string, newStatus: string, expectedApprovalHash?: string) {
+interface PreparedDraftStatus {
+  outreachId: string;
+  previousStatus: string | null;
+  newStatus: string;
+  metadata: string | null;
+  updatedAt: Date;
+}
+
+async function prepareDraftStatus(
+  userId: string,
+  outreachId: string,
+  newStatus: string,
+  expectedApprovalHash?: string,
+): Promise<PreparedDraftStatus> {
   const db = await getDb();
   if (!db) throw new Error("Database not available");
 
@@ -376,10 +383,7 @@ async function setDraftStatus(userId: string, outreachId: string, newStatus: str
   )[0];
   if (!row || !row.caseId) throw new Error("Outreach draft not found");
 
-  // Ownership: the draft's case must belong to the user.
   await assertCaseOwnership(row.caseId, userId);
-
-  // Phase 059: enforce the outreach state machine (PendingApproval -> Approved/Rejected).
   assertOutreachTransition(row.status ?? null, newStatus);
   const updatedAt = new Date();
   let metadata = row.metadata;
@@ -394,7 +398,6 @@ async function setDraftStatus(userId: string, outreachId: string, newStatus: str
       lawyerEmail: lawyer?.email,
     });
     if (!expectedApprovalHash || expectedApprovalHash !== message.approvalHash) {
-      const { TRPCError } = await import("@trpc/server");
       throw new TRPCError({
         code: "CONFLICT",
         message: "The outreach message changed after review. Review the current recipient and message before approving.",
@@ -411,34 +414,58 @@ async function setDraftStatus(userId: string, outreachId: string, newStatus: str
       }),
     });
   }
-  const result = await db
+
+  return {
+    outreachId,
+    previousStatus: row.status ?? null,
+    newStatus,
+    metadata,
+    updatedAt,
+  };
+}
+
+function applyDraftStatusInTransaction(tx: any, userId: string, draft: PreparedDraftStatus) {
+  const result = tx
     .update(outreachStatus)
-    .set({ status: newStatus, metadata, updatedAt })
+    .set({ status: draft.newStatus, metadata: draft.metadata, updatedAt: draft.updatedAt })
     .where(and(
-      eq(outreachStatus.id, outreachId),
-      row.status == null ? isNull(outreachStatus.status) : eq(outreachStatus.status, row.status),
-    ));
+      eq(outreachStatus.id, draft.outreachId),
+      draft.previousStatus == null
+        ? isNull(outreachStatus.status)
+        : eq(outreachStatus.status, draft.previousStatus),
+    ))
+    .run();
   if (Number(result.changes || 0) !== 1) {
-    const { TRPCError } = await import("@trpc/server");
     throw new TRPCError({ code: "CONFLICT", message: "The outreach draft changed before this action completed. Refresh and try again." });
   }
-
-  await createAuditLog({
+  writeAuditLogOrThrow(tx, {
     userId,
     action: AUDIT_ACTIONS.OUTREACH_STATUS_CHANGED,
     entityType: "outreach",
-    entityId: outreachId,
-    details: { from: row.status, to: newStatus },
+    entityId: draft.outreachId,
+    details: { from: draft.previousStatus, to: draft.newStatus },
   });
+}
 
-  await createNotification({ // Phase 027
+async function notifyDraftStatus(userId: string, newStatus: string) {
+  await createNotification({
     userId,
-    title: newStatus === "Approved" ? "Outreach draft approved" : "Outreach draft rejected",
+    title: newStatus === OUTREACH_APPROVED ? "Outreach draft approved" : "Outreach draft rejected",
     body:
-      newStatus === "Approved"
+      newStatus === OUTREACH_APPROVED
         ? "The draft is marked ready to send. No message has been sent yet."
         : "The draft was rejected and will not be sent.",
   });
+}
+
+async function setDraftStatus(userId: string, outreachId: string, newStatus: string, expectedApprovalHash?: string) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const prepared = await prepareDraftStatus(userId, outreachId, newStatus, expectedApprovalHash);
+  db.transaction((tx: any) => {
+    applyDraftStatusInTransaction(tx, userId, prepared);
+  });
+  await notifyDraftStatus(userId, newStatus);
 
   // Approving marks the draft ready-to-send; actual transmission is a later
   // phase and additionally gated by the `outreach.send.enabled` feature flag

--- a/tests/backend/realSend.test.ts
+++ b/tests/backend/realSend.test.ts
@@ -218,7 +218,8 @@ suite('Real outreach send (011/026/017)', () => {
         (await import('drizzle-orm')).eq(app.schema.auditLogs.action, 'outreach.status_changed'),
       )
     );
-    expect(auditRows).toHaveLength(2);
+    expect(auditRows).toHaveLength(3);
+    expect(auditRows.filter((entry: any) => entry.details?.includes('"to":"Dispatching"'))).toHaveLength(1);
     expect(auditRows.filter((entry: any) => entry.details?.includes('"to":"Sent"'))).toHaveLength(1);
 
     await setFlag('outreach.send.enabled', false);

--- a/tests/backend/realSend.test.ts
+++ b/tests/backend/realSend.test.ts
@@ -382,6 +382,16 @@ suite('Real outreach send (011/026/017)', () => {
       (await import('drizzle-orm')).eq(app.schema.systemConfig.configKey, `sent:${oid}`)
     );
     expect(guards).toHaveLength(0);
+    const auditRows = await app.db.select().from(app.schema.auditLogs).where(
+      (await import('drizzle-orm')).and(
+        (await import('drizzle-orm')).eq(app.schema.auditLogs.entityId, oid),
+        (await import('drizzle-orm')).eq(app.schema.auditLogs.action, 'outreach.status_changed'),
+      )
+    );
+    expect(auditRows.filter((entry: any) => entry.details?.includes('"to":"Dispatching"'))).toHaveLength(1);
+    expect(auditRows.filter((entry: any) =>
+      entry.details?.includes('"from":"Dispatching"') && entry.details?.includes('"to":"Approved"')
+    )).toHaveLength(1);
     await setFlag('outreach.send.enabled', false);
   });
 });

--- a/tests/security/caseTransitionAtomicity.test.ts
+++ b/tests/security/caseTransitionAtomicity.test.ts
@@ -1,8 +1,11 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { eq } from "drizzle-orm";
 import { bootTestApp, sqliteAvailable, type TestApp } from "../helpers/app";
-import { buildCase, buildUser } from "../factories";
+import { buildCase, buildLawyer, buildUser } from "../factories";
 import { compareAndSetCaseStatus } from "../../server/caseTransitions";
+import { linkInboundOutreachReply } from "../../server/inboundOutreach";
+import { sendApprovedOutreach } from "../../server/outreachSend";
+import { setFlag } from "../../server/featureFlags";
 
 const suite = sqliteAvailable ? describe : describe.skip;
 
@@ -16,6 +19,19 @@ suite("atomic case status transitions", () => {
   });
 
   afterAll(() => app?.cleanup());
+
+  function rejectAuditAction(action: string, triggerName: string): () => void {
+    const sqlite = app.db.$client;
+    sqlite.exec(`
+      CREATE TRIGGER ${triggerName}
+      BEFORE INSERT ON audit_logs
+      WHEN NEW.action = '${action}'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected audit failure');
+      END;
+    `);
+    return () => sqlite.exec(`DROP TRIGGER IF EXISTS ${triggerName}`);
+  }
 
   it("allows only one transition from the same observed status", async () => {
     await app.db.insert(app.schema.cases).values(buildCase({
@@ -143,5 +159,348 @@ suite("atomic case status transitions", () => {
       .from(app.schema.cases)
       .where(eq(app.schema.cases.id, "CASE_OUTREACH_NO_MATCH"));
     expect(stored.status).toBe("Matching");
+  });
+
+  it("rolls back a case transition when its required audit record cannot be written", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_AUDIT_ROLLBACK",
+      userId: owner.id,
+      status: "Matching",
+    }));
+    const releaseFailure = rejectAuditAction("case.status_changed", "reject_case_transition_audit");
+    try {
+      await expect(app.makeCaller(owner).cases.update({
+        id: "CASE_AUDIT_ROLLBACK",
+        status: "Outreach",
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+    }
+
+    const [stored] = await app.db
+      .select({ status: app.schema.cases.status })
+      .from(app.schema.cases)
+      .where(eq(app.schema.cases.id, "CASE_AUDIT_ROLLBACK"));
+    expect(stored.status).toBe("Matching");
+  });
+
+  it("rolls back case creation when its required audit record cannot be written", async () => {
+    const releaseFailure = rejectAuditAction("case.created", "reject_case_creation_audit");
+    try {
+      await expect(app.makeCaller(owner).cases.create({
+        clientName: "Audit creation rollback",
+        clientEmail: "audit-create@example.com",
+        caseType: "Employment",
+        caseSummary: "Employment agreement review and dismissal dispute.",
+        urgency: "Medium",
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+    }
+
+    const stored = await app.db
+      .select({ id: app.schema.cases.id })
+      .from(app.schema.cases)
+      .where(eq(app.schema.cases.clientEmail, "audit-create@example.com"));
+    expect(stored).toHaveLength(0);
+  });
+
+  it("rolls back case detail updates when their required audit record cannot be written", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_DETAILS_AUDIT_ROLLBACK",
+      userId: owner.id,
+      caseSummary: "Original summary",
+    }));
+    const releaseFailure = rejectAuditAction("case.updated", "reject_case_details_audit");
+    try {
+      await expect(app.makeCaller(owner).cases.update({
+        id: "CASE_DETAILS_AUDIT_ROLLBACK",
+        caseSummary: "Changed summary",
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+    }
+
+    const [stored] = await app.db
+      .select({ caseSummary: app.schema.cases.caseSummary })
+      .from(app.schema.cases)
+      .where(eq(app.schema.cases.id, "CASE_DETAILS_AUDIT_ROLLBACK"));
+    expect(stored.caseSummary).toBe("Original summary");
+  });
+
+  it("rolls back case deletion when its required audit record cannot be written", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_DELETE_AUDIT_ROLLBACK",
+      userId: owner.id,
+    }));
+    const releaseFailure = rejectAuditAction("case.deleted", "reject_case_delete_audit");
+    try {
+      await expect(app.makeCaller(owner).cases.delete({
+        id: "CASE_DELETE_AUDIT_ROLLBACK",
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+    }
+
+    const stored = await app.db
+      .select({ id: app.schema.cases.id })
+      .from(app.schema.cases)
+      .where(eq(app.schema.cases.id, "CASE_DELETE_AUDIT_ROLLBACK"));
+    expect(stored).toHaveLength(1);
+  });
+
+  it("rolls back an interested response when its required audit record cannot be written", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_RESPONSE_AUDIT_ROLLBACK",
+      userId: owner.id,
+      status: "Outreach",
+    }));
+    await app.db.insert(app.schema.outreachStatus).values({
+      id: "OUTREACH_RESPONSE_AUDIT_ROLLBACK",
+      caseId: "CASE_RESPONSE_AUDIT_ROLLBACK",
+      status: "Sent",
+      initialContact: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const releaseFailure = rejectAuditAction("email.response_received", "reject_response_audit");
+    try {
+      await expect(app.makeCaller(owner).workflow.recordResponse({
+        outreachId: "OUTREACH_RESPONSE_AUDIT_ROLLBACK",
+        response: "Interested",
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+    }
+
+    const [outreach] = await app.db
+      .select({ status: app.schema.outreachStatus.status })
+      .from(app.schema.outreachStatus)
+      .where(eq(app.schema.outreachStatus.id, "OUTREACH_RESPONSE_AUDIT_ROLLBACK"));
+    const [caseRow] = await app.db
+      .select({ status: app.schema.cases.status })
+      .from(app.schema.cases)
+      .where(eq(app.schema.cases.id, "CASE_RESPONSE_AUDIT_ROLLBACK"));
+    expect(outreach.status).toBe("Sent");
+    expect(caseRow.status).toBe("Outreach");
+  });
+
+  it("rolls back outreach initiation and draft creation when its audit cannot be written", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_INIT_AUDIT_ROLLBACK",
+      userId: owner.id,
+      status: "Matching",
+    }));
+    await app.db.insert(app.schema.lawyers).values(buildLawyer({ id: "LAWYER_INIT_AUDIT_ROLLBACK" }));
+    const releaseFailure = rejectAuditAction("outreach.initiated", "reject_initiation_audit");
+    try {
+      await expect(app.makeCaller(owner).workflow.initiateOutreach({
+        caseId: "CASE_INIT_AUDIT_ROLLBACK",
+        maxResults: 1,
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+    }
+
+    const [caseRow] = await app.db
+      .select({ status: app.schema.cases.status })
+      .from(app.schema.cases)
+      .where(eq(app.schema.cases.id, "CASE_INIT_AUDIT_ROLLBACK"));
+    const drafts = await app.db
+      .select({ id: app.schema.outreachStatus.id })
+      .from(app.schema.outreachStatus)
+      .where(eq(app.schema.outreachStatus.caseId, "CASE_INIT_AUDIT_ROLLBACK"));
+    expect(caseRow.status).toBe("Matching");
+    expect(drafts).toHaveLength(0);
+  });
+
+  it("rolls back draft approval when its audit cannot be written", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_APPROVAL_AUDIT_ROLLBACK",
+      userId: owner.id,
+      status: "Outreach",
+    }));
+    await app.db.insert(app.schema.lawyers).values(buildLawyer({ id: "LAWYER_APPROVAL_AUDIT_ROLLBACK" }));
+    await app.db.insert(app.schema.outreachStatus).values({
+      id: "OUTREACH_APPROVAL_AUDIT_ROLLBACK",
+      caseId: "CASE_APPROVAL_AUDIT_ROLLBACK",
+      lawyerId: "LAWYER_APPROVAL_AUDIT_ROLLBACK",
+      status: "PendingApproval",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const caller = app.makeCaller(owner);
+    const review = await caller.workflow.preSendReview({ outreachId: "OUTREACH_APPROVAL_AUDIT_ROLLBACK" });
+    const releaseFailure = rejectAuditAction("outreach.status_changed", "reject_approval_audit");
+    try {
+      await expect(caller.workflow.approveDraft({
+        outreachId: "OUTREACH_APPROVAL_AUDIT_ROLLBACK",
+        approvalHash: review.message.approvalHash,
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+    }
+
+    const [stored] = await app.db
+      .select({ status: app.schema.outreachStatus.status })
+      .from(app.schema.outreachStatus)
+      .where(eq(app.schema.outreachStatus.id, "OUTREACH_APPROVAL_AUDIT_ROLLBACK"));
+    expect(stored.status).toBe("PendingApproval");
+  });
+
+  it("rolls back every draft when one audit in a batch approval fails", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_BATCH_AUDIT_ROLLBACK",
+      userId: owner.id,
+      status: "Outreach",
+    }));
+    await app.db.insert(app.schema.lawyers).values([
+      buildLawyer({ id: "LAWYER_BATCH_AUDIT_ONE" }),
+      buildLawyer({ id: "LAWYER_BATCH_AUDIT_TWO" }),
+    ]);
+    await app.db.insert(app.schema.outreachStatus).values([
+      {
+        id: "OUTREACH_BATCH_AUDIT_ONE",
+        caseId: "CASE_BATCH_AUDIT_ROLLBACK",
+        lawyerId: "LAWYER_BATCH_AUDIT_ONE",
+        status: "PendingApproval",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "OUTREACH_BATCH_AUDIT_TWO",
+        caseId: "CASE_BATCH_AUDIT_ROLLBACK",
+        lawyerId: "LAWYER_BATCH_AUDIT_TWO",
+        status: "PendingApproval",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    const caller = app.makeCaller(owner);
+    const firstReview = await caller.workflow.preSendReview({ outreachId: "OUTREACH_BATCH_AUDIT_ONE" });
+    const secondReview = await caller.workflow.preSendReview({ outreachId: "OUTREACH_BATCH_AUDIT_TWO" });
+    const sqlite = app.db.$client;
+    sqlite.exec(`
+      CREATE TRIGGER reject_second_batch_approval_audit
+      BEFORE INSERT ON audit_logs
+      WHEN NEW.action = 'outreach.status_changed'
+        AND NEW.entityId = 'OUTREACH_BATCH_AUDIT_TWO'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected batch audit failure');
+      END;
+    `);
+    try {
+      await expect(caller.workflow.approveDrafts({ approvals: [
+        { outreachId: "OUTREACH_BATCH_AUDIT_ONE", approvalHash: firstReview.message.approvalHash },
+        { outreachId: "OUTREACH_BATCH_AUDIT_TWO", approvalHash: secondReview.message.approvalHash },
+      ] })).rejects.toThrow();
+    } finally {
+      sqlite.exec("DROP TRIGGER IF EXISTS reject_second_batch_approval_audit");
+    }
+
+    const rows = await app.db
+      .select({ id: app.schema.outreachStatus.id, status: app.schema.outreachStatus.status })
+      .from(app.schema.outreachStatus)
+      .where(eq(app.schema.outreachStatus.caseId, "CASE_BATCH_AUDIT_ROLLBACK"));
+    expect(rows).toEqual(expect.arrayContaining([
+      { id: "OUTREACH_BATCH_AUDIT_ONE", status: "PendingApproval" },
+      { id: "OUTREACH_BATCH_AUDIT_TWO", status: "PendingApproval" },
+    ]));
+  });
+
+  it("rolls back Gmail reply linking when its required audit cannot be written", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_INBOUND_AUDIT_ROLLBACK",
+      userId: owner.id,
+      status: "Outreach",
+    }));
+    await app.db.insert(app.schema.lawyers).values(buildLawyer({
+      id: "LAWYER_INBOUND_AUDIT_ROLLBACK",
+      email: "inbound-audit@example.com",
+    }));
+    await app.db.insert(app.schema.outreachStatus).values({
+      id: "OUTREACH_INBOUND_AUDIT_ROLLBACK",
+      caseId: "CASE_INBOUND_AUDIT_ROLLBACK",
+      lawyerId: "LAWYER_INBOUND_AUDIT_ROLLBACK",
+      status: "Sent",
+      initialContact: new Date("2026-08-20T10:00:00Z"),
+      metadata: JSON.stringify({
+        outboundProviderMessageId: "outbound-audit-message",
+        outboundRecipient: "inbound-audit@example.com",
+        outboundSubject: "Legal outreach",
+      }),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const releaseFailure = rejectAuditAction("email.response_received", "reject_inbound_reply_audit");
+    try {
+      await expect(linkInboundOutreachReply({
+        userId: owner.id,
+        caseId: "CASE_INBOUND_AUDIT_ROLLBACK",
+        message: {
+          gmailMessageId: "gmail-inbound-audit-failure",
+          from: "inbound-audit@example.com",
+          subject: "Re: Legal outreach",
+          body: "I have reviewed your request.",
+          receivedAt: new Date("2026-08-21T10:00:00Z"),
+          inReplyTo: "<outbound-audit-message>",
+        },
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+    }
+
+    const [stored] = await app.db
+      .select({ responseReceived: app.schema.outreachStatus.responseReceived, metadata: app.schema.outreachStatus.metadata })
+      .from(app.schema.outreachStatus)
+      .where(eq(app.schema.outreachStatus.id, "OUTREACH_INBOUND_AUDIT_ROLLBACK"));
+    expect(stored.responseReceived).not.toBe("Yes");
+    expect(JSON.parse(stored.metadata || "{}").inboundGmailMessageIds).toBeUndefined();
+  });
+
+  it("does not contact a provider when the dispatch claim audit cannot be written", async () => {
+    await app.db.insert(app.schema.cases).values(buildCase({
+      id: "CASE_DISPATCH_AUDIT_ROLLBACK",
+      userId: owner.id,
+      status: "Outreach",
+    }));
+    await app.db.insert(app.schema.lawyers).values(buildLawyer({
+      id: "LAWYER_DISPATCH_AUDIT_ROLLBACK",
+      email: "dispatch-audit@example.com",
+    }));
+    await app.db.insert(app.schema.outreachStatus).values({
+      id: "OUTREACH_DISPATCH_AUDIT_ROLLBACK",
+      caseId: "CASE_DISPATCH_AUDIT_ROLLBACK",
+      lawyerId: "LAWYER_DISPATCH_AUDIT_ROLLBACK",
+      status: "PendingApproval",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const caller = app.makeCaller(owner);
+    const review = await caller.workflow.preSendReview({ outreachId: "OUTREACH_DISPATCH_AUDIT_ROLLBACK" });
+    await caller.workflow.approveDraft({
+      outreachId: "OUTREACH_DISPATCH_AUDIT_ROLLBACK",
+      approvalHash: review.message.approvalHash,
+    });
+
+    await setFlag("outreach.send.enabled", true);
+    const releaseFailure = rejectAuditAction("outreach.status_changed", "reject_dispatch_claim_audit");
+    let providerCalled = false;
+    try {
+      await expect(sendApprovedOutreach(owner.id, "OUTREACH_DISPATCH_AUDIT_ROLLBACK", async () => {
+        providerCalled = true;
+        return { delivered: true, provider: "test" };
+      })).rejects.toThrow();
+    } finally {
+      releaseFailure();
+      await setFlag("outreach.send.enabled", false);
+    }
+
+    const [stored] = await app.db
+      .select({ status: app.schema.outreachStatus.status })
+      .from(app.schema.outreachStatus)
+      .where(eq(app.schema.outreachStatus.id, "OUTREACH_DISPATCH_AUDIT_ROLLBACK"));
+    expect(providerCalled).toBe(false);
+    expect(stored.status).toBe("Approved");
   });
 });


### PR DESCRIPTION
## Summary
- commit required case and outreach audit evidence in the same transaction as the legal state change
- make single and batch outreach approvals compare-and-set and all-or-nothing
- prevent provider contact when a dispatch claim cannot be audited, and make Gmail reply linking atomic
- document the strengthened integrity boundary and current verification evidence

## Verification
- 
pm.cmd run gate
- 98 test files, 600 tests passed
- 0 dependency vulnerabilities
- 117/117 traceability rows cited
- 0 suspect runtime placeholders
- 0 high-severity account-safety findings
- Electron and Flask recovery drills passed

## External boundary
- no live email was sent and no live Google account was accessed in this change
- provider-live acceptance remains represented only by the repository's existing owner-controlled acceptance record